### PR TITLE
feat(website): tracker improvements Feb 25

### DIFF
--- a/website/TODO.md
+++ b/website/TODO.md
@@ -6,37 +6,35 @@
 
 ## Feature Ideas
 
-- [ ] **#3 — Bid & Won: add denominator context** — Show "8 bids won out of X total bids" rather than a raw count. The `bidAndWonPct` field exists in the snapshot; total bids attempted needs to be surfaced from the data pipeline (bid attempts vs. bid wins).
-
-- [x] **#5 — Overall Rankings table: collapse streak/milestone columns** — The table has 11 columns and overflows on normal viewports. Collapse Win Streak, Loss Streak, Fivples, Tenples, FiveMottes into a single "Milestones" cell showing compact badges, e.g. 🔥×14 ⚡×1 💀×4.
+- [ ] **Bid & Won: add denominator context** — Show "8 bids won out of X total bids" rather than a raw count.
 
 - [ ] **Biggest Rivalry card** — 5th highlight card on the tournament detail page showing the most evenly contested pair (closest to 50/50 win rate with high game count), as a counterpart to Best Pair.
 
-- [ ] **Tournaments list filter** — Filter bar on the Tournaments list page (28+ entries) by tournament type (Championship / Friendly / Special) or by winner.
+- [ ] **"Latest" badge** — Add a small "Latest" pill to the most recent tournament card on the Tournaments page.
 
-- [ ] **Comeback badge on Tournaments list** — Small "comeback" tag next to any tournament in the list where the winner trailed at the midpoint.
+- [ ] **Wiki-style tournament history page** — Rich table per type (Championships, Mini, Tiny, Friendlies) with columns for #, Name, Location, Dates, Year, #Games, Champion, Second, Third, Other players.
 
-- [ ] **Wiki-style tournament history page** — Create a dedicated page (or section on the Tournaments page) that mirrors the GitHub wiki layout: a rich table per tournament type (Championships, Mini, Tiny, Friendlies) with columns for #, Name, Location 🏴, Dates, Year, #Games, Champion 🏆, Second, Third, Other players. Include trophy counts next to player names (e.g. "Akash 🏆6") and emoji flags for location. Data for names, locations, and dates will need to be sourced from the wiki or added to the data pipeline.
-
-- [ ] **More tournament widgets** — Build additional per-tournament widgets: biggest winning margin per round, most dominant game (highest single-round score), longest win/loss streak within the tournament, score distribution histogram, and a "momentum" chart showing rolling win rate across the tournament.
-
-- [ ] **Fix Head-to-Head page data representation** — The current H2H page has display issues. Review the pairwise data structure (same-team stats, not direct matchups), fix the rivalry cards and per-tournament breakdown chart, and ensure the matchup selector correctly reflects who played together vs. against each other.
-
-- [ ] **"Latest" badge** — Add a small "Latest" pill to the most recent tournament card on the Tournaments page
-- [ ] **Career Stats page** — Dedicated page showing each player's all-time bid success rate, career streaks, total Fivples/Tenples/FiveMottes (data already in the JSON via `careerStats`)
-- [ ] **Player profile pages** — Clicking a player name opens a dedicated page with their full tournament history, best/worst performances, and streaks
-- [ ] **Mobile sidebar** — Slide-in drawer with hamburger toggle for a better phone experience
-- [ ] **GitHub Actions CI/CD** — Add `.github/workflows/deploy-website.yml` and `requirements.txt` to the repo. The workflow runs `python process_data.py` → `pnpm build` → deploys to Cloudflare Pages on every push to `main`. Requires two GitHub Secrets: `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`. See the workflow file content in the conversation history.
-- [ ] **Export to GitHub** — Push project to GitHub repo via Settings → GitHub in the Management UI
+- [ ] **GitHub Actions CI/CD** — Add `.github/workflows/deploy-website.yml` and `requirements.txt`. Workflow: `python process_data.py` → `pnpm build` → deploy. Requires `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets.
 
 ## Completed
 
 - [x] Build initial website with Dashboard, Rankings, Tournaments, Head-to-Head pages
 - [x] Implement Elo-style per-game rating system from `ScoreOverTime.ipynb`
-- [x] Fix standings denominator to match notebook (TotalGames = all rounds, same for all players)
+- [x] Fix standings denominator to match notebook
 - [x] Add Win Ratio Over Time chart to Tournament Detail page
-- [x] Add Pair Performance section (same-team stats with Wins + Losses + AvgPoints)
-- [x] Add Trio Performance section (3-player combination stats)
+- [x] Add Pair Performance and Trio Performance sections
 - [x] Add Bid & Won section to Tournament Detail page
-- [x] Add Post-Tournament Leaderboard with Elo rating changes, rank movement, streaks, Fivples/Tenples/FiveMottes
+- [x] Add Post-Tournament Leaderboard with Elo rating changes, rank movement, streaks, milestones
 - [x] Display tournaments most-recent-first on Tournaments page
+- [x] Overall Rankings table: collapse streak/milestone columns into badges
+- [x] Rebuild Head-to-Head page with clearer W–L layout
+- [x] Bid stats: bidAttempts/bidWins/bidWinRate in pipeline and UI
+- [x] Milestone Achievements section on tournament detail pages
+- [x] Career Stats page
+- [x] Player Profile pages
+- [x] Display numbering uses CSV filename numbers (TC#11 not TC#10)
+- [x] Best Bid Rate hero card requires ≥10 attempts
+- [x] Low-sample bid rates show attempt count instead of ~75%* asterisk
+- [x] Dashboard Rating History shows full 34-tournament history
+- [x] Career Stats Win Rate & Bid Rate bar charts render with player colours
+- [x] Player Profile chart x-axis: C#1, TC#7 instead of T2/T4/T6

--- a/website/client/src/App.tsx
+++ b/website/client/src/App.tsx
@@ -9,6 +9,8 @@ import TournamentsPage from "./pages/TournamentsPage";
 import TournamentDetailPage from "./pages/TournamentDetailPage";
 import RankingsPage from "./pages/RankingsPage";
 import HeadToHeadPage from "./pages/HeadToHeadPage";
+import CareerStatsPage from "./pages/CareerStatsPage";
+import PlayerProfilePage from "./pages/PlayerProfilePage";
 
 function Router() {
   return (
@@ -18,6 +20,8 @@ function Router() {
       <Route path="/tournaments" component={TournamentsPage} />
       <Route path="/tournaments/:id" component={TournamentDetailPage} />
       <Route path="/head-to-head" component={HeadToHeadPage} />
+      <Route path="/career-stats" component={CareerStatsPage} />
+      <Route path="/players/:player" component={PlayerProfilePage} />
       <Route path="/404" component={NotFound} />
       <Route component={NotFound} />
     </Switch>

--- a/website/client/src/components/Layout.tsx
+++ b/website/client/src/components/Layout.tsx
@@ -5,7 +5,7 @@
  */
 import { Link, useLocation } from "wouter";
 import { cn } from "@/lib/utils";
-import { Trophy, BarChart3, Swords, LayoutDashboard, Menu, X } from "lucide-react";
+import { Trophy, BarChart3, Swords, LayoutDashboard, Menu, X, Medal } from "lucide-react";
 import { useState } from "react";
 
 const NAV_ITEMS = [
@@ -13,6 +13,7 @@ const NAV_ITEMS = [
   { href: "/rankings", label: "Rankings", icon: BarChart3 },
   { href: "/tournaments", label: "Tournaments", icon: Trophy },
   { href: "/head-to-head", label: "Head to Head", icon: Swords },
+  { href: "/career-stats", label: "Career Stats", icon: Medal },
 ];
 
 interface LayoutProps {
@@ -66,7 +67,7 @@ export default function Layout({ children }: LayoutProps) {
         {/* Nav Items */}
         <nav className="flex-1 px-3 py-4 space-y-1">
           {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
-            const isActive = location === href;
+            const isActive = location === href || (href === "/career-stats" && location.startsWith("/players/"));
             return (
               <Link key={href} href={href}>
                 <div

--- a/website/client/src/lib/gameData.ts
+++ b/website/client/src/lib/gameData.ts
@@ -77,6 +77,9 @@ export interface TournamentPlayerSnapshot {
   numFivles: number;
   numTenples: number;
   fiveMottes: number;
+  fivplesThisTourney: number;
+  tenplesThisTourney: number;
+  fiveMottesThisTourney: number;
 }
 
 export interface CareerStats {
@@ -93,6 +96,9 @@ export interface CareerStats {
   numFivles: number;
   numTenples: number;
   fiveMottes: number;
+  fivplesThisTourney: number;
+  tenplesThisTourney: number;
+  fiveMottesThisTourney: number;
 }
 
 export interface Tournament {

--- a/website/client/src/pages/CareerStatsPage.tsx
+++ b/website/client/src/pages/CareerStatsPage.tsx
@@ -1,0 +1,437 @@
+/*
+ * CareerStatsPage — Dark Casino / Art Deco Design System
+ * All-time career stats comparison across all core players
+ * Sections: Hero stats, Comparison table, Win rate chart, Bid success, Milestones
+ */
+import { useEffect, useState } from "react";
+import Layout from "@/components/Layout";
+import { fetchGameData, type GameData } from "@/lib/gameData";
+import { motion } from "framer-motion";
+import {
+  BarChart, Bar, Cell, XAxis, YAxis, Tooltip, ResponsiveContainer,
+  RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis,
+  LineChart, Line, Legend, CartesianGrid,
+} from "recharts";
+import { PLAYER_COLORS, getPlayerColor } from "@/lib/gameData";
+import { Trophy, Zap, Crown, Egg, Flame, Skull, Target, TrendingUp } from "lucide-react";
+
+const GOLD = "oklch(0.78 0.15 85)";
+const DIM = "oklch(0.55 0.02 85)";
+const CARD_BG = "oklch(0.13 0.016 155)";
+const BORDER = "oklch(0.22 0.03 155)";
+const FELT = "oklch(0.10 0.012 155)";
+
+function SectionHeader({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <div className="px-5 py-4" style={{ borderBottom: `1px solid ${BORDER}` }}>
+      <h2 className="text-base font-semibold tracking-wide" style={{ color: GOLD, fontFamily: "'Playfair Display', serif" }}>
+        {title}
+      </h2>
+      {subtitle && <p className="text-xs mt-0.5" style={{ color: DIM }}>{subtitle}</p>}
+    </div>
+  );
+}
+
+const CORE_PLAYERS = ["Akash", "Nats", "Prateek", "Abhi", "Ani", "Naati", "Skanda"];
+
+export default function CareerStatsPage() {
+  const [data, setData] = useState<GameData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetchGameData()
+      .then(d => { setData(d); setLoading(false); })
+      .catch(() => { setError(true); setLoading(false); });
+  }, []);
+
+  if (loading) {
+    return (
+      <Layout>
+        <div className="flex items-center justify-center h-64" style={{ color: DIM }}>
+          Loading career stats…
+        </div>
+      </Layout>
+    );
+  }
+  if (error || !data) {
+    return (
+      <Layout>
+        <div className="flex items-center justify-center h-64" style={{ color: "oklch(0.65 0.15 20)" }}>
+          Failed to load data.
+        </div>
+      </Layout>
+    );
+  }
+
+  const { careerStats, allTimeStats, ratingHistory, tournamentSummary, players } = data;
+
+  // Core players only (ordered by career games desc)
+  const corePlayers = CORE_PLAYERS.filter(p => careerStats[p]);
+
+  // Build per-player tournament participation count
+  const tourneyCount: Record<string, number> = {};
+  for (const t of tournamentSummary) {
+    for (const p of t.players) {
+      tourneyCount[p] = (tourneyCount[p] || 0) + 1;
+    }
+  }
+
+  // Tournament wins per player
+  const tourneyWins: Record<string, number> = {};
+  for (const t of tournamentSummary) {
+    if (t.winner) tourneyWins[t.winner] = (tourneyWins[t.winner] || 0) + 1;
+  }
+
+  // Build combined rows
+  const rows = corePlayers.map(p => {
+    const cs = careerStats[p];
+    const ats = allTimeStats.find((s: { player: string }) => s.player === p);
+    return {
+      player: p,
+      careerGames: cs.careerGames,
+      careerWins: cs.careerWins,
+      winPct: cs.winPct,
+      avgPoints: ats?.avgPoints ?? 0,
+      totalPoints: ats?.totalPoints ?? 0,
+      tourneyPlayed: tourneyCount[p] || 0,
+      tourneyWins: tourneyWins[p] || 0,
+      bidAttempts: cs.bidAttempts,
+      bidWins: cs.bidWins,
+      bidWinRate: cs.bidWinRate,
+      bestWinStreak: cs.bestWinStreak,
+      worstLossStreak: cs.worstLossStreak,
+      numFivles: cs.numFivles,
+      numTenples: cs.numTenples,
+      fiveMottes: cs.fiveMottes,
+    };
+  }).sort((a, b) => b.winPct - a.winPct);
+
+  // Win rate bar chart data
+  const winRateData = rows.map(r => ({ name: r.player, winRate: r.winPct }));
+
+  // Bid success bar chart data — require at least 10 attempts for a meaningful rate
+  const BID_MIN_ATTEMPTS = 10;
+  const bidData = rows
+    .filter(r => r.bidAttempts >= BID_MIN_ATTEMPTS && r.bidWinRate !== null)
+    .map(r => ({ name: r.player, bidRate: r.bidWinRate as number, attempts: r.bidAttempts }));
+
+  // Milestone bar chart
+  const milestoneData = rows.map(r => ({
+    name: r.player,
+    Fivples: r.numFivles,
+    Tenples: r.numTenples,
+    FiveMottes: r.fiveMottes,
+  }));
+
+  // Rating history line chart — last 28 entries
+  const ratingData = ratingHistory.slice(1); // skip index 0 (all 1000)
+
+  // Radar chart: normalise each metric to 0–100 across players
+  const maxWinPct = Math.max(...rows.map(r => r.winPct));
+  const maxAvgPts = Math.max(...rows.map(r => r.avgPoints));
+  const maxTourneyWins = Math.max(...rows.map(r => r.tourneyWins));
+  const maxFivples = Math.max(...rows.map(r => r.numFivles));
+  const maxBidRate = Math.max(...rows.filter(r => r.bidWinRate !== null).map(r => r.bidWinRate as number));
+
+  const radarData = [
+    { metric: "Win %", ...Object.fromEntries(rows.map(r => [r.player, Math.round((r.winPct / maxWinPct) * 100)])) },
+    { metric: "Avg Pts", ...Object.fromEntries(rows.map(r => [r.player, Math.round((r.avgPoints / maxAvgPts) * 100)])) },
+    { metric: "Tourney Wins", ...Object.fromEntries(rows.map(r => [r.player, Math.round((r.tourneyWins / (maxTourneyWins || 1)) * 100)])) },
+    { metric: "Fivples", ...Object.fromEntries(rows.map(r => [r.player, Math.round((r.numFivles / (maxFivples || 1)) * 100)])) },
+    { metric: "Bid Rate", ...Object.fromEntries(rows.map(r => [r.player, r.bidWinRate !== null ? Math.round((r.bidWinRate / (maxBidRate || 1)) * 100) : 0])) },
+  ];
+
+  const tooltipStyle = {
+    backgroundColor: "oklch(0.14 0.018 155)",
+    border: `1px solid ${BORDER}`,
+    borderRadius: "6px",
+    color: "oklch(0.88 0.02 85)",
+    fontSize: "12px",
+  };
+
+  return (
+    <Layout>
+      <div className="p-4 md:p-6 space-y-5 max-w-6xl mx-auto">
+
+        {/* Page header */}
+        <motion.div initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }}>
+          <h1
+            className="text-2xl md:text-3xl font-bold tracking-tight"
+            style={{ color: GOLD, fontFamily: "'Playfair Display', serif" }}
+          >
+            Career Stats
+          </h1>
+          <p className="text-sm mt-1" style={{ color: DIM }}>
+            All-time records across {tournamentSummary.length} tournaments
+          </p>
+        </motion.div>
+
+        {/* Hero stat cards */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          {(() => {
+            const topWins = [...rows].sort((a,b)=>b.tourneyWins-a.tourneyWins)[0];
+            const topWinRate = [...rows].sort((a,b)=>b.winPct-a.winPct)[0];
+            const topFivples = [...rows].sort((a,b)=>b.numFivles-a.numFivles)[0];
+            const sortedBid = [...bidData].sort((a,b)=>b.bidRate-a.bidRate);
+            const topBid = sortedBid[0];
+            return [
+              { label: "Most Tournament Wins", value: topWins?.player, sub: `${topWins?.tourneyWins} wins`, icon: Trophy },
+              { label: "Highest Win Rate", value: topWinRate?.player, sub: `${topWinRate?.winPct}%`, icon: TrendingUp },
+              { label: "Most Fivples", value: topFivples?.player, sub: `${topFivples?.numFivles} Fivples`, icon: Zap },
+              { label: "Best Bid Rate", value: topBid?.name ?? "—", sub: topBid ? `${topBid.bidRate.toFixed(1)}% (${topBid.attempts} bids)` : "—", icon: Target },
+            ];
+          })().map(({ label, value, sub, icon: Icon }, i) => (
+            <motion.div
+              key={label}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: i * 0.06 }}
+              className="rounded-lg p-4"
+              style={{ background: CARD_BG, border: `1px solid ${BORDER}` }}
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <Icon size={14} style={{ color: GOLD }} />
+                <span className="text-xs uppercase tracking-wider" style={{ color: DIM }}>{label}</span>
+              </div>
+              <div className="text-lg font-bold" style={{ color: getPlayerColor(value || ""), fontFamily: "'Playfair Display', serif" }}>
+                {value}
+              </div>
+              <div className="text-xs mt-0.5" style={{ color: DIM }}>{sub}</div>
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Comparison table */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.15 }}
+          className="rounded-lg overflow-hidden"
+          style={{ background: CARD_BG, border: `1px solid ${BORDER}` }}
+        >
+          <SectionHeader title="All-Time Comparison" subtitle="Sorted by win percentage" />
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr style={{ borderBottom: `1px solid ${BORDER}` }}>
+                  {["Player", "Games", "Wins", "Win %", "Avg Pts", "Tourneys", "🏆 Wins", "Bid Rate", "🔥 Streak", "💀 Streak", "⚡ Fivples", "👑 Tenples", "🥚 FiveMottes"].map(h => (
+                    <th key={h} className="px-3 py-3 text-left text-xs font-semibold uppercase tracking-wider whitespace-nowrap" style={{ color: DIM }}>
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r, i) => (
+                  <motion.tr
+                    key={r.player}
+                    initial={{ opacity: 0, x: -10 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    transition={{ delay: 0.2 + i * 0.05 }}
+                    className="transition-colors"
+                    style={{ borderBottom: i < rows.length - 1 ? `1px solid oklch(0.15 0.018 155)` : "none" }}
+                    onMouseEnter={e => (e.currentTarget.style.background = "oklch(0.15 0.018 155)")}
+                    onMouseLeave={e => (e.currentTarget.style.background = "transparent")}
+                  >
+                    <td className="px-3 py-3">
+                      <div className="flex items-center gap-2">
+                        <div className="w-2 h-2 rounded-full" style={{ background: getPlayerColor(r.player) }} />
+                        <span className="font-semibold" style={{ color: getPlayerColor(r.player) }}>{r.player}</span>
+                      </div>
+                    </td>
+                    <td className="px-3 py-3" style={{ color: "oklch(0.80 0.015 85)" }}>{r.careerGames.toLocaleString()}</td>
+                    <td className="px-3 py-3" style={{ color: "oklch(0.80 0.015 85)" }}>{r.careerWins.toLocaleString()}</td>
+                    <td className="px-3 py-3">
+                      <span className="font-semibold" style={{ color: r.winPct >= 55 ? "oklch(0.75 0.18 155)" : r.winPct >= 50 ? GOLD : "oklch(0.65 0.12 20)" }}>
+                        {r.winPct}%
+                      </span>
+                    </td>
+                    <td className="px-3 py-3" style={{ color: "oklch(0.80 0.015 85)" }}>{r.avgPoints.toFixed(1)}</td>
+                    <td className="px-3 py-3" style={{ color: "oklch(0.80 0.015 85)" }}>{r.tourneyPlayed}</td>
+                    <td className="px-3 py-3">
+                      <span style={{ color: r.tourneyWins > 0 ? GOLD : DIM }}>{r.tourneyWins}</span>
+                    </td>
+                    <td className="px-3 py-3">
+                      {r.bidAttempts >= BID_MIN_ATTEMPTS && r.bidWinRate !== null
+                        ? <span style={{ color: r.bidWinRate >= 50 ? "oklch(0.75 0.18 155)" : "oklch(0.80 0.015 85)" }}>{r.bidWinRate.toFixed(1)}%</span>
+                        : r.bidAttempts > 0
+                          ? <span style={{ color: DIM }} title={`Only ${r.bidAttempts} bid attempts — too few to rank`}>{r.bidWinRate?.toFixed(0)}% <span className="text-xs" style={{ color: "oklch(0.45 0.02 85)" }}>({r.bidAttempts})</span></span>
+                          : <span style={{ color: DIM }}>—</span>
+                      }
+                    </td>
+                    <td className="px-3 py-3">
+                      <span style={{ color: r.bestWinStreak >= 10 ? GOLD : r.bestWinStreak >= 5 ? "oklch(0.75 0.18 155)" : "oklch(0.80 0.015 85)" }}>
+                        {r.bestWinStreak}
+                      </span>
+                    </td>
+                    <td className="px-3 py-3">
+                      <span style={{ color: r.worstLossStreak >= 5 ? "oklch(0.65 0.12 20)" : "oklch(0.80 0.015 85)" }}>
+                        {r.worstLossStreak}
+                      </span>
+                    </td>
+                    <td className="px-3 py-3" style={{ color: "oklch(0.80 0.015 85)" }}>{r.numFivles}</td>
+                    <td className="px-3 py-3" style={{ color: r.numTenples > 0 ? GOLD : DIM }}>{r.numTenples}</td>
+                    <td className="px-3 py-3" style={{ color: "oklch(0.80 0.015 85)" }}>{r.fiveMottes}</td>
+                  </motion.tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </motion.div>
+
+        {/* Charts row 1: Win Rate + Bid Rate */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.3 }}
+            className="rounded-lg overflow-hidden"
+            style={{ background: CARD_BG, border: `1px solid ${BORDER}` }}
+          >
+            <SectionHeader title="Win Rate" subtitle="Career win percentage per player" />
+            <div className="p-4" style={{ height: 220 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={winRateData} margin={{ top: 5, right: 10, left: -20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="oklch(0.18 0.02 155)" />
+                  <XAxis dataKey="name" tick={{ fill: DIM, fontSize: 11 }} axisLine={false} tickLine={false} />
+                  <YAxis tick={{ fill: DIM, fontSize: 10 }} domain={[40, 65]} axisLine={false} tickLine={false} />
+                  <Tooltip
+                    contentStyle={tooltipStyle}
+                    formatter={(v: number) => [`${v}%`, "Win Rate"]}
+                  />
+                  <Bar dataKey="winRate" radius={[4, 4, 0, 0]}>
+                    {winRateData.map((entry) => (
+                      <Cell key={entry.name} fill={getPlayerColor(entry.name)} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.35 }}
+            className="rounded-lg overflow-hidden"
+            style={{ background: CARD_BG, border: `1px solid ${BORDER}` }}
+          >
+            <SectionHeader title="Bid Success Rate" subtitle="Win % when named as bidder (14 tournaments)" />
+            <div className="p-4" style={{ height: 220 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={bidData} margin={{ top: 5, right: 10, left: -20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="oklch(0.18 0.02 155)" />
+                  <XAxis dataKey="name" tick={{ fill: DIM, fontSize: 11 }} axisLine={false} tickLine={false} />
+                  <YAxis tick={{ fill: DIM, fontSize: 10 }} domain={[30, 60]} axisLine={false} tickLine={false} />
+                  <Tooltip
+                    contentStyle={tooltipStyle}
+                    formatter={(v: number, name: string) => name === "bidRate" ? [`${v.toFixed(1)}%`, "Bid Win Rate"] : [v, "Attempts"]}
+                  />
+                  <Bar dataKey="bidRate" radius={[4, 4, 0, 0]}>
+                    {bidData.map((entry) => (
+                      <Cell key={entry.name} fill={getPlayerColor(entry.name)} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </motion.div>
+        </div>
+
+        {/* Charts row 2: Milestones + Rating History */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.4 }}
+            className="rounded-lg overflow-hidden"
+            style={{ background: CARD_BG, border: `1px solid ${BORDER}` }}
+          >
+            <SectionHeader title="Milestone Totals" subtitle="Career Fivples, Tenples, and FiveMottes" />
+            <div className="p-4" style={{ height: 220 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={milestoneData} margin={{ top: 5, right: 10, left: -20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="oklch(0.18 0.02 155)" />
+                  <XAxis dataKey="name" tick={{ fill: DIM, fontSize: 11 }} axisLine={false} tickLine={false} />
+                  <YAxis tick={{ fill: DIM, fontSize: 10 }} axisLine={false} tickLine={false} />
+                  <Tooltip contentStyle={tooltipStyle} />
+                  <Legend wrapperStyle={{ fontSize: 11, color: DIM }} />
+                  <Bar dataKey="Fivples" stackId="a" fill="oklch(0.55 0.18 155)" radius={[0,0,0,0]} />
+                  <Bar dataKey="Tenples" stackId="a" fill={GOLD} radius={[0,0,0,0]} />
+                  <Bar dataKey="FiveMottes" stackId="a" fill="oklch(0.50 0.10 20)" radius={[4,4,0,0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.45 }}
+            className="rounded-lg overflow-hidden"
+            style={{ background: CARD_BG, border: `1px solid ${BORDER}` }}
+          >
+            <SectionHeader title="Rating History" subtitle="Elo rating progression across all tournaments" />
+            <div className="p-4" style={{ height: 220 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={ratingData} margin={{ top: 5, right: 10, left: -20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="oklch(0.18 0.02 155)" />
+                  <XAxis dataKey="tournament" tick={{ fill: DIM, fontSize: 10 }} axisLine={false} tickLine={false} />
+                  <YAxis tick={{ fill: DIM, fontSize: 10 }} domain={["auto", "auto"]} axisLine={false} tickLine={false} />
+                  <Tooltip contentStyle={tooltipStyle} />
+                  <Legend wrapperStyle={{ fontSize: 11, color: DIM }} />
+                  {corePlayers.map(p => (
+                    <Line
+                      key={p}
+                      type="monotone"
+                      dataKey={p}
+                      stroke={getPlayerColor(p)}
+                      strokeWidth={1.5}
+                      dot={false}
+                      activeDot={{ r: 3 }}
+                    />
+                  ))}
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </motion.div>
+        </div>
+
+        {/* Radar chart */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.5 }}
+          className="rounded-lg overflow-hidden"
+          style={{ background: CARD_BG, border: `1px solid ${BORDER}` }}
+        >
+          <SectionHeader title="Player Profiles (Radar)" subtitle="Normalised across Win %, Avg Points, Tournament Wins, Fivples, and Bid Rate" />
+          <div className="p-4" style={{ height: 320 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <RadarChart data={radarData} cx="50%" cy="50%" outerRadius="70%">
+                <PolarGrid stroke="oklch(0.22 0.03 155)" />
+                <PolarAngleAxis dataKey="metric" tick={{ fill: DIM, fontSize: 11 }} />
+                <PolarRadiusAxis angle={30} domain={[0, 100]} tick={false} axisLine={false} />
+                {corePlayers.map(p => (
+                  <Radar
+                    key={p}
+                    name={p}
+                    dataKey={p}
+                    stroke={getPlayerColor(p)}
+                    fill={getPlayerColor(p)}
+                    fillOpacity={0.08}
+                    strokeWidth={1.5}
+                  />
+                ))}
+                <Legend wrapperStyle={{ fontSize: 11, color: DIM }} />
+                <Tooltip contentStyle={tooltipStyle} />
+              </RadarChart>
+            </ResponsiveContainer>
+          </div>
+        </motion.div>
+
+      </div>
+    </Layout>
+  );
+}

--- a/website/client/src/pages/HeadToHeadPage.tsx
+++ b/website/client/src/pages/HeadToHeadPage.tsx
@@ -1,78 +1,109 @@
 /*
  * Head-to-Head Page — Dark Casino / Art Deco Design System
- * All-time pairwise (same-team) stats, matchup selector, win rate visualization
  *
- * Note: "Head-to-Head" here means same-team pair performance across all tournaments.
- * wins/losses = times both players were on the same winning/losing side.
+ * Data note: "Head-to-Head" here means same-team pair performance.
+ * wins = rounds both players were on the WINNING side together
+ * losses = rounds both players were on the LOSING side together
+ * winPct = wins / (wins + losses)
+ *
+ * The MatchupCard shows: W–L record + win% bar + avg points (when available)
  */
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import { Swords, Users2 } from "lucide-react";
+import { Swords, Users2, TrendingUp } from "lucide-react";
 import Layout from "@/components/Layout";
-import { fetchGameData, getPlayerColor, type GameData, type AllTimePairwiseStat } from "@/lib/gameData";
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from "recharts";
+import {
+  fetchGameData,
+  getPlayerColor,
+  type GameData,
+  type AllTimePairwiseStat,
+} from "@/lib/gameData";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Legend,
+} from "recharts";
 
-// CORE_PLAYERS is derived dynamically from data.players (populated from game_data.json)
-// Any player with >200 total games qualifies as core — see process_data.py
-
-function MatchupCard({ pw, index }: { pw: AllTimePairwiseStat; index: number }) {
+// ── MatchupCard ────────────────────────────────────────────────────────────────
+function MatchupCard({
+  pw,
+  index,
+  onClick,
+}: {
+  pw: AllTimePairwiseStat;
+  index: number;
+  onClick?: () => void;
+}) {
   const p1Color = getPlayerColor(pw.player1);
   const p2Color = getPlayerColor(pw.player2);
-  const p1WinPct = pw.winPct;
-  const p2WinPct = 100 - p1WinPct;
-  const dominant = p1WinPct >= p2WinPct ? pw.player1 : pw.player2;
+  const winPct = pw.winPct;
+  const lossPct = 100 - winPct;
 
   return (
     <motion.div
       initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ delay: Math.min(index * 0.05, 0.6) }}
-      className="felt-card rounded-lg p-4"
+      transition={{ delay: Math.min(index * 0.04, 0.5) }}
+      onClick={onClick}
+      className="felt-card rounded-lg p-4 cursor-pointer transition-all hover:ring-1"
+      style={{ "--tw-ring-color": "oklch(0.78 0.15 85 / 0.4)" } as React.CSSProperties}
     >
-      {/* Players */}
-      <div className="flex items-center justify-between mb-3">
-        <div className="text-center">
-          <div className="w-8 h-8 rounded-full mx-auto mb-1 flex items-center justify-center text-xs font-bold"
-            style={{ background: p1Color + "33", color: p1Color, border: `1px solid ${p1Color}55` }}>
-            {pw.player1[0]}
-          </div>
-          <div className="text-xs font-semibold" style={{ color: p1Color }}>{pw.player1}</div>
-          <div className="text-xl font-bold rank-number mt-0.5" style={{ color: p1Color }}>{pw.wins}</div>
-        </div>
+      {/* Players row */}
+      <div className="flex items-center gap-2 mb-3">
+        <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: p1Color }} />
+        <span className="text-xs font-semibold" style={{ color: p1Color }}>{pw.player1}</span>
+        <span className="text-xs" style={{ color: "oklch(0.40 0.02 85)" }}>+</span>
+        <div className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: p2Color }} />
+        <span className="text-xs font-semibold" style={{ color: p2Color }}>{pw.player2}</span>
+        <span className="ml-auto text-xs" style={{ color: "oklch(0.45 0.02 85)" }}>
+          {pw.totalGames} games
+        </span>
+      </div>
 
-        <div className="flex-1 px-3">
-          <div className="text-center text-xs mb-2" style={{ color: "oklch(0.45 0.02 85)" }}>
-            {pw.totalGames} games together
-          </div>
-          {/* Win bar */}
-          <div className="h-2 rounded-full overflow-hidden flex" style={{ background: "oklch(0.18 0.02 155)" }}>
-            <div className="h-full transition-all" style={{ width: `${p1WinPct}%`, background: p1Color }} />
-            <div className="h-full transition-all" style={{ width: `${p2WinPct}%`, background: p2Color }} />
-          </div>
-          <div className="flex justify-between mt-1">
-            <span className="text-xs rank-number" style={{ color: p1Color }}>{p1WinPct.toFixed(0)}%</span>
-            <span className="text-xs rank-number" style={{ color: p2Color }}>{p2WinPct.toFixed(0)}%</span>
-          </div>
-          <div className="text-center mt-1">
-            <span className="text-xs" style={{ color: "oklch(0.45 0.02 85)" }}>
-              {dominant} leads
-            </span>
-          </div>
-        </div>
+      {/* W–L record */}
+      <div className="flex items-baseline gap-1 mb-2">
+        <span className="text-2xl font-bold rank-number" style={{ color: "oklch(0.78 0.15 85)" }}>
+          {pw.wins}
+        </span>
+        <span className="text-sm" style={{ color: "oklch(0.40 0.02 85)" }}>W</span>
+        <span className="text-sm mx-1" style={{ color: "oklch(0.30 0.02 85)" }}>–</span>
+        <span className="text-2xl font-bold rank-number" style={{ color: "oklch(0.60 0.02 85)" }}>
+          {pw.losses}
+        </span>
+        <span className="text-sm" style={{ color: "oklch(0.40 0.02 85)" }}>L</span>
+        <span
+          className="ml-auto text-xs font-semibold rank-number"
+          style={{ color: winPct >= 50 ? "oklch(0.78 0.15 85)" : "oklch(0.60 0.02 85)" }}
+        >
+          {winPct.toFixed(0)}%
+        </span>
+      </div>
 
-        <div className="text-center">
-          <div className="w-8 h-8 rounded-full mx-auto mb-1 flex items-center justify-center text-xs font-bold"
-            style={{ background: p2Color + "33", color: p2Color, border: `1px solid ${p2Color}55` }}>
-            {pw.player2[0]}
-          </div>
-          <div className="text-xs font-semibold" style={{ color: p2Color }}>{pw.player2}</div>
-          <div className="text-xl font-bold rank-number mt-0.5" style={{ color: p2Color }}>{pw.losses}</div>
-        </div>
+      {/* Win rate bar */}
+      <div className="h-1.5 rounded-full overflow-hidden" style={{ background: "oklch(0.18 0.02 155)" }}>
+        <div
+          className="h-full rounded-full transition-all"
+          style={{
+            width: `${winPct}%`,
+            background:
+              winPct >= 60
+                ? "oklch(0.78 0.15 85)"
+                : winPct >= 50
+                ? "oklch(0.65 0.10 155)"
+                : "oklch(0.55 0.05 85)",
+          }}
+        />
       </div>
     </motion.div>
   );
 }
 
+// ── Main page ──────────────────────────────────────────────────────────────────
 export default function HeadToHeadPage() {
   const [data, setData] = useState<GameData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -83,106 +114,161 @@ export default function HeadToHeadPage() {
     fetchGameData().then(setData).finally(() => setLoading(false));
   }, []);
 
-  // Core players come from the JSON (dynamic: >200 games threshold)
-  const corePlayers = data?.players || ["Akash", "Abhi", "Ani", "Nats", "Naati", "Prateek", "Skanda"];
+  const corePlayers = data?.players || ["Akash", "Abhi", "Ani", "Nats", "Naati", "Prateek"];
 
-  // Find the selected matchup (player1 < player2 alphabetically in data)
+  // Find the selected pair (order-independent)
   const selectedMatchup = data?.allTimePairwise.find(
     (pw) =>
       (pw.player1 === selectedP1 && pw.player2 === selectedP2) ||
       (pw.player1 === selectedP2 && pw.player2 === selectedP1)
   );
 
-  // Normalize: always show selectedP1 as "player1" side
-  const normalizedMatchup = selectedMatchup
+  // Normalize so selectedP1 is always on the left
+  const nm = selectedMatchup
     ? selectedMatchup.player1 === selectedP1
-      ? { ...selectedMatchup, p1Wins: selectedMatchup.wins, p2Wins: selectedMatchup.losses, p1WinPct: selectedMatchup.winPct }
-      : { ...selectedMatchup, player1: selectedMatchup.player2, player2: selectedMatchup.player1,
-          p1Wins: selectedMatchup.losses, p2Wins: selectedMatchup.wins, p1WinPct: 100 - selectedMatchup.winPct }
+      ? {
+          wins: selectedMatchup.wins,
+          losses: selectedMatchup.losses,
+          winPct: selectedMatchup.winPct,
+          totalGames: selectedMatchup.totalGames,
+        }
+      : {
+          wins: selectedMatchup.losses,
+          losses: selectedMatchup.wins,
+          winPct: 100 - selectedMatchup.winPct,
+          totalGames: selectedMatchup.totalGames,
+        }
     : null;
 
-  // Per-player win record against all others (using wins/losses from AllTimePairwiseStat)
-  const playerWinRecords = corePlayers.map((player) => {
-    const matchups = (data?.allTimePairwise || []).filter(
-      (pw) => pw.player1 === player || pw.player2 === player
-    );
-    const wins = matchups.reduce((sum, pw) => {
-      return sum + (pw.player1 === player ? pw.wins : pw.losses);
-    }, 0);
-    const losses = matchups.reduce((sum, pw) => {
-      return sum + (pw.player1 === player ? pw.losses : pw.wins);
-    }, 0);
-    const total = wins + losses;
-    return {
-      player,
-      wins,
-      losses,
-      total,
-      winPct: total > 0 ? Math.round((wins / total) * 100) : 0,
-    };
-  }).sort((a, b) => b.winPct - a.winPct);
-
-  // Tournament-by-tournament matchup history
+  // Per-tournament breakdown: one bar per tournament where both played together
   const matchupHistory = selectedMatchup
     ? (data?.tournaments || [])
         .filter((t) => t.players.includes(selectedP1) && t.players.includes(selectedP2))
         .map((t) => {
-          const pw = t.pairwiseStats.find(
+          const pw = t.pairwiseStats?.find(
             (p) =>
               (p.Player_x === selectedP1 && p.Player_y === selectedP2) ||
               (p.Player_x === selectedP2 && p.Player_y === selectedP1)
           );
           if (!pw) return null;
-          const p1Wins = pw.Player_x === selectedP1 ? pw.Wins : pw.Losses;
-          const p2Wins = pw.Player_x === selectedP1 ? pw.Losses : pw.Wins;
+          const wins = pw.Player_x === selectedP1 ? pw.Wins : pw.Losses;
+          const losses = pw.Player_x === selectedP1 ? pw.Losses : pw.Wins;
+          const winPct = pw.Player_x === selectedP1 ? pw.WinPercentage : 100 - pw.WinPercentage;
           return {
-            name: t.displayName.replace("Championship", "C").replace("International Friendly", "IF").replace("Mini ", "M").replace("Tiny ", "T"),
-            [selectedP1]: p1Wins,
-            [selectedP2]: p2Wins,
+            name: t.displayName
+              .replace("Championship", "C")
+              .replace("International Friendly", "IF")
+              .replace("Mini ", "M")
+              .replace("Tiny ", "T"),
+            fullName: t.displayName,
+            Wins: wins,
+            Losses: losses,
+            WinPct: Math.round(winPct),
+            AvgPts: pw.AvgPoints ?? null,
           };
         })
-        .filter(Boolean)
+        .filter(Boolean) as {
+          name: string;
+          fullName: string;
+          Wins: number;
+          Losses: number;
+          WinPct: number;
+          AvgPts: number | null;
+        }[]
     : [];
+
+  // Overall pair win record (aggregated across all opponents)
+  const playerPairRecords = corePlayers
+    .map((player) => {
+      const matchups = (data?.allTimePairwise || []).filter(
+        (pw) => pw.player1 === player || pw.player2 === player
+      );
+      const wins = matchups.reduce(
+        (sum, pw) => sum + (pw.player1 === player ? pw.wins : pw.losses),
+        0
+      );
+      const losses = matchups.reduce(
+        (sum, pw) => sum + (pw.player1 === player ? pw.losses : pw.wins),
+        0
+      );
+      const total = wins + losses;
+      return {
+        player,
+        wins,
+        losses,
+        total,
+        winPct: total > 0 ? Math.round((wins / total) * 100) : 0,
+      };
+    })
+    .sort((a, b) => b.winPct - a.winPct);
+
+  // Sort all-pair cards: most games first
+  const sortedPairs = (data?.allTimePairwise || [])
+    .filter((pw) => corePlayers.includes(pw.player1) && corePlayers.includes(pw.player2))
+    .sort((a, b) => b.totalGames - a.totalGames);
+
+  const p1Color = getPlayerColor(selectedP1);
+  const p2Color = getPlayerColor(selectedP2);
 
   return (
     <Layout>
       <div className="container py-8 space-y-8">
         {/* Page header */}
         <div>
-          <div className="text-xs uppercase tracking-[0.3em] mb-1" style={{ color: "oklch(0.78 0.15 85)" }}>
-            ♠ Rivalry Records
+          <div
+            className="text-xs uppercase tracking-[0.3em] mb-1"
+            style={{ color: "oklch(0.78 0.15 85)" }}
+          >
+            ♠ Pair Records
           </div>
-          <h1 className="text-3xl font-bold" style={{ fontFamily: "'Playfair Display', serif", color: "oklch(0.92 0.015 85)" }}>
-            Pair Performance
+          <h1
+            className="text-3xl font-bold"
+            style={{ fontFamily: "'Playfair Display', serif", color: "oklch(0.92 0.015 85)" }}
+          >
+            Head to Head
           </h1>
           <p className="text-sm mt-1" style={{ color: "oklch(0.55 0.02 85)" }}>
-            Win/loss records when players are on the same side of the table
+            Win/loss records when two players are on the same side of the table
           </p>
         </div>
 
-        {/* Matchup Selector */}
-        <div className="felt-card rounded-lg p-6">
-          <div className="flex items-center gap-2 mb-5">
+        {/* ── Matchup Selector ─────────────────────────────────────────────── */}
+        <div className="felt-card rounded-lg p-6 space-y-6">
+          <div className="flex items-center gap-2">
             <Swords size={16} style={{ color: "oklch(0.78 0.15 85)" }} />
-            <h2 className="font-semibold" style={{ fontFamily: "'Playfair Display', serif", color: "oklch(0.92 0.015 85)" }}>
+            <h2
+              className="font-semibold"
+              style={{ fontFamily: "'Playfair Display', serif", color: "oklch(0.92 0.015 85)" }}
+            >
               Select Pair
             </h2>
           </div>
 
-          <div className="flex flex-wrap items-center gap-4">
+          <div className="flex flex-wrap items-start gap-6">
+            {/* Player 1 */}
             <div>
-              <div className="text-xs mb-2" style={{ color: "oklch(0.50 0.02 85)" }}>Player 1</div>
+              <div className="text-xs mb-2" style={{ color: "oklch(0.50 0.02 85)" }}>
+                Player 1
+              </div>
               <div className="flex gap-2 flex-wrap">
                 {corePlayers.map((p) => (
                   <button
                     key={p}
-                    onClick={() => { if (p !== selectedP2) setSelectedP1(p); }}
+                    onClick={() => {
+                      if (p !== selectedP2) setSelectedP1(p);
+                    }}
                     disabled={p === selectedP2}
                     className="px-3 py-1.5 rounded text-xs font-medium transition-all disabled:opacity-30"
                     style={{
-                      background: selectedP1 === p ? getPlayerColor(p) + "33" : "oklch(0.16 0.02 155)",
-                      color: selectedP1 === p ? getPlayerColor(p) : "oklch(0.60 0.02 85)",
-                      border: `1px solid ${selectedP1 === p ? getPlayerColor(p) + "66" : "oklch(0.22 0.03 155)"}`,
+                      background:
+                        selectedP1 === p ? getPlayerColor(p) + "33" : "oklch(0.16 0.02 155)",
+                      color:
+                        selectedP1 === p ? getPlayerColor(p) : "oklch(0.60 0.02 85)",
+                      border: `1px solid ${
+                        selectedP1 === p
+                          ? getPlayerColor(p) + "66"
+                          : "oklch(0.22 0.03 155)"
+                      }`,
                     }}
                   >
                     {p}
@@ -191,21 +277,37 @@ export default function HeadToHeadPage() {
               </div>
             </div>
 
-            <div className="text-2xl font-bold" style={{ color: "oklch(0.35 0.04 155)" }}>+</div>
+            <div
+              className="text-2xl font-bold self-end pb-1"
+              style={{ color: "oklch(0.35 0.04 155)" }}
+            >
+              +
+            </div>
 
+            {/* Player 2 */}
             <div>
-              <div className="text-xs mb-2" style={{ color: "oklch(0.50 0.02 85)" }}>Player 2</div>
+              <div className="text-xs mb-2" style={{ color: "oklch(0.50 0.02 85)" }}>
+                Player 2
+              </div>
               <div className="flex gap-2 flex-wrap">
                 {corePlayers.map((p) => (
                   <button
                     key={p}
-                    onClick={() => { if (p !== selectedP1) setSelectedP2(p); }}
+                    onClick={() => {
+                      if (p !== selectedP1) setSelectedP2(p);
+                    }}
                     disabled={p === selectedP1}
                     className="px-3 py-1.5 rounded text-xs font-medium transition-all disabled:opacity-30"
                     style={{
-                      background: selectedP2 === p ? getPlayerColor(p) + "33" : "oklch(0.16 0.02 155)",
-                      color: selectedP2 === p ? getPlayerColor(p) : "oklch(0.60 0.02 85)",
-                      border: `1px solid ${selectedP2 === p ? getPlayerColor(p) + "66" : "oklch(0.22 0.03 155)"}`,
+                      background:
+                        selectedP2 === p ? getPlayerColor(p) + "33" : "oklch(0.16 0.02 155)",
+                      color:
+                        selectedP2 === p ? getPlayerColor(p) : "oklch(0.60 0.02 85)",
+                      border: `1px solid ${
+                        selectedP2 === p
+                          ? getPlayerColor(p) + "66"
+                          : "oklch(0.22 0.03 155)"
+                      }`,
                     }}
                   >
                     {p}
@@ -215,155 +317,321 @@ export default function HeadToHeadPage() {
             </div>
           </div>
 
-          {/* Matchup result */}
-          {normalizedMatchup && (
+          {/* ── Matchup result panel ─────────────────────────────────────── */}
+          {nm && (
             <motion.div
               key={`${selectedP1}-${selectedP2}`}
               initial={{ opacity: 0, y: 8 }}
               animate={{ opacity: 1, y: 0 }}
-              className="mt-6 p-5 rounded-lg"
-              style={{ background: "oklch(0.16 0.02 155)", border: "1px solid oklch(0.22 0.03 155)" }}
+              className="rounded-lg p-5"
+              style={{
+                background: "oklch(0.16 0.02 155)",
+                border: "1px solid oklch(0.22 0.03 155)",
+              }}
             >
-              <div className="grid grid-cols-3 gap-4 items-center">
-                <div className="text-center">
-                  <div className="text-4xl font-bold rank-number" style={{ color: getPlayerColor(selectedP1) }}>
-                    {normalizedMatchup.p1Wins}
-                  </div>
-                  <div className="text-sm font-semibold mt-1" style={{ color: getPlayerColor(selectedP1) }}>
+              {/* Header row */}
+              <div className="flex items-center justify-between mb-4">
+                <div className="flex items-center gap-2">
+                  <div className="w-3 h-3 rounded-full" style={{ background: p1Color }} />
+                  <span className="font-semibold" style={{ color: p1Color }}>
                     {selectedP1}
-                  </div>
-                  <div className="text-xs mt-0.5" style={{ color: "oklch(0.45 0.02 85)" }}>
-                    {normalizedMatchup.p1WinPct.toFixed(1)}% win rate
-                  </div>
-                </div>
-
-                <div className="text-center">
-                  <div className="text-xs uppercase tracking-widest mb-2" style={{ color: "oklch(0.40 0.02 85)" }}>
-                    {normalizedMatchup.totalGames} games together
-                  </div>
-                  <div className="h-2 rounded-full overflow-hidden flex">
-                    <div className="h-full" style={{ width: `${normalizedMatchup.p1WinPct}%`, background: getPlayerColor(selectedP1) }} />
-                    <div className="h-full" style={{ width: `${100 - normalizedMatchup.p1WinPct}%`, background: getPlayerColor(selectedP2) }} />
-                  </div>
-                  <div className="text-xs mt-2" style={{ color: "oklch(0.45 0.02 85)" }}>
-                    {normalizedMatchup.p1WinPct > 50 ? selectedP1 : selectedP2} leads all-time
-                  </div>
-                </div>
-
-                <div className="text-center">
-                  <div className="text-4xl font-bold rank-number" style={{ color: getPlayerColor(selectedP2) }}>
-                    {normalizedMatchup.p2Wins}
-                  </div>
-                  <div className="text-sm font-semibold mt-1" style={{ color: getPlayerColor(selectedP2) }}>
+                  </span>
+                  <span className="text-xs" style={{ color: "oklch(0.40 0.02 85)" }}>
+                    +
+                  </span>
+                  <div className="w-3 h-3 rounded-full" style={{ background: p2Color }} />
+                  <span className="font-semibold" style={{ color: p2Color }}>
                     {selectedP2}
+                  </span>
+                </div>
+                <span className="text-xs" style={{ color: "oklch(0.45 0.02 85)" }}>
+                  {nm.totalGames} games together
+                </span>
+              </div>
+
+              {/* W–L big numbers */}
+              <div className="grid grid-cols-2 gap-4 mb-4">
+                <div
+                  className="rounded-lg p-4 text-center"
+                  style={{ background: "oklch(0.20 0.04 155)" }}
+                >
+                  <div
+                    className="text-4xl font-bold rank-number"
+                    style={{ color: "oklch(0.78 0.15 85)" }}
+                  >
+                    {nm.wins}
                   </div>
-                  <div className="text-xs mt-0.5" style={{ color: "oklch(0.45 0.02 85)" }}>
-                    {(100 - normalizedMatchup.p1WinPct).toFixed(1)}% win rate
+                  <div className="text-xs mt-1" style={{ color: "oklch(0.55 0.02 85)" }}>
+                    Wins together
+                  </div>
+                  <div
+                    className="text-sm font-semibold mt-0.5 rank-number"
+                    style={{ color: "oklch(0.78 0.15 85)" }}
+                  >
+                    {nm.winPct.toFixed(1)}%
                   </div>
                 </div>
+                <div
+                  className="rounded-lg p-4 text-center"
+                  style={{ background: "oklch(0.16 0.02 155)" }}
+                >
+                  <div
+                    className="text-4xl font-bold rank-number"
+                    style={{ color: "oklch(0.50 0.02 85)" }}
+                  >
+                    {nm.losses}
+                  </div>
+                  <div className="text-xs mt-1" style={{ color: "oklch(0.45 0.02 85)" }}>
+                    Losses together
+                  </div>
+                  <div
+                    className="text-sm font-semibold mt-0.5 rank-number"
+                    style={{ color: "oklch(0.50 0.02 85)" }}
+                  >
+                    {(100 - nm.winPct).toFixed(1)}%
+                  </div>
+                </div>
+              </div>
+
+              {/* Win rate bar */}
+              <div className="h-2 rounded-full overflow-hidden mb-1" style={{ background: "oklch(0.18 0.02 155)" }}>
+                <div
+                  className="h-full rounded-full transition-all"
+                  style={{
+                    width: `${nm.winPct}%`,
+                    background:
+                      nm.winPct >= 60
+                        ? "oklch(0.78 0.15 85)"
+                        : nm.winPct >= 50
+                        ? "oklch(0.65 0.10 155)"
+                        : "oklch(0.55 0.05 85)",
+                  }}
+                />
+              </div>
+              <div className="text-xs text-center" style={{ color: "oklch(0.45 0.02 85)" }}>
+                {nm.winPct > 50
+                  ? `${selectedP1} & ${selectedP2} win more than they lose together`
+                  : nm.winPct < 50
+                  ? `${selectedP1} & ${selectedP2} lose more than they win together`
+                  : `${selectedP1} & ${selectedP2} are perfectly balanced together`}
               </div>
             </motion.div>
           )}
 
-          {/* Per-tournament breakdown */}
+          {/* ── Per-tournament breakdown chart ───────────────────────────── */}
           {matchupHistory.length > 0 && (
-            <div className="mt-4">
-              <div className="text-xs mb-2" style={{ color: "oklch(0.50 0.02 85)" }}>
-                Wins per tournament when playing together
+            <div>
+              <div className="text-xs mb-3 font-medium" style={{ color: "oklch(0.65 0.02 85)" }}>
+                Per-tournament record when playing together
               </div>
-              <ResponsiveContainer width="100%" height={160}>
-                <BarChart data={matchupHistory} margin={{ top: 4, right: 8, bottom: 4, left: -20 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="oklch(0.18 0.02 155)" />
-                  <XAxis dataKey="name" tick={{ fontSize: 9, fill: "oklch(0.45 0.02 85)" }} />
-                  <YAxis tick={{ fontSize: 9, fill: "oklch(0.45 0.02 85)" }} />
-                  <Tooltip
-                    contentStyle={{
-                      background: "oklch(0.13 0.015 155)",
-                      border: "1px solid oklch(0.25 0.04 155)",
-                      borderRadius: "6px",
-                      fontSize: "11px",
-                      color: "oklch(0.88 0.015 85)",
-                    }}
-                  />
-                  <Bar dataKey={selectedP1} fill={getPlayerColor(selectedP1)} radius={[2, 2, 0, 0]} />
-                  <Bar dataKey={selectedP2} fill={getPlayerColor(selectedP2)} radius={[2, 2, 0, 0]} />
-                </BarChart>
-              </ResponsiveContainer>
+              <div className="overflow-x-auto">
+                <div style={{ minWidth: Math.max(matchupHistory.length * 40, 400) }}>
+                  <ResponsiveContainer width="100%" height={180}>
+                    <BarChart
+                      data={matchupHistory}
+                      margin={{ top: 4, right: 8, bottom: 24, left: -20 }}
+                      barCategoryGap="25%"
+                    >
+                      <CartesianGrid
+                        strokeDasharray="3 3"
+                        stroke="oklch(0.18 0.02 155)"
+                        vertical={false}
+                      />
+                      <XAxis
+                        dataKey="name"
+                        tick={{ fontSize: 9, fill: "oklch(0.45 0.02 85)" }}
+                        angle={-35}
+                        textAnchor="end"
+                        interval={0}
+                      />
+                      <YAxis
+                        tick={{ fontSize: 9, fill: "oklch(0.45 0.02 85)" }}
+                        allowDecimals={false}
+                      />
+                      <Tooltip
+                        contentStyle={{
+                          background: "oklch(0.13 0.015 155)",
+                          border: "1px solid oklch(0.25 0.04 155)",
+                          borderRadius: "6px",
+                          fontSize: "11px",
+                          color: "oklch(0.88 0.015 85)",
+                        }}
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        formatter={(value: any, name: any) => [
+                          value,
+                          name === "Wins" ? "Wins together" : "Losses together",
+                        ]}
+                        labelFormatter={(label, payload) =>
+                          payload?.[0]
+                            ? (payload[0].payload as { fullName: string }).fullName
+                            : label
+                        }
+                      />
+                      <Legend
+                        wrapperStyle={{ fontSize: 10, color: "oklch(0.55 0.02 85)" }}
+                        formatter={(value) =>
+                          value === "Wins" ? "Wins together" : "Losses together"
+                        }
+                      />
+                      <Bar
+                        dataKey="Wins"
+                        fill="oklch(0.78 0.15 85)"
+                        radius={[2, 2, 0, 0]}
+                        opacity={0.9}
+                      />
+                      <Bar
+                        dataKey="Losses"
+                        fill="oklch(0.40 0.04 155)"
+                        radius={[2, 2, 0, 0]}
+                        opacity={0.8}
+                      />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </div>
             </div>
           )}
         </div>
 
-        {/* All matchup cards */}
+        {/* ── All Pair Records ─────────────────────────────────────────────── */}
         <div>
-          <h2 className="font-semibold text-lg mb-4" style={{ fontFamily: "'Playfair Display', serif", color: "oklch(0.92 0.015 85)" }}>
+          <h2
+            className="font-semibold text-lg mb-1"
+            style={{ fontFamily: "'Playfair Display', serif", color: "oklch(0.92 0.015 85)" }}
+          >
             All Pair Records
           </h2>
+          <p className="text-xs mb-4" style={{ color: "oklch(0.50 0.02 85)" }}>
+            Click any card to load that pair in the selector above
+          </p>
           {loading ? (
-            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
               {[...Array(6)].map((_, i) => (
-                <div key={i} className="felt-card rounded-lg h-36 animate-pulse" />
+                <div key={i} className="felt-card rounded-lg h-24 animate-pulse" />
               ))}
             </div>
           ) : (
-            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {(data?.allTimePairwise || [])
-                .filter((pw) => corePlayers.includes(pw.player1) && corePlayers.includes(pw.player2))
-                .sort((a, b) => b.totalGames - a.totalGames)
-                .map((pw, i) => (
-                  <MatchupCard key={`${pw.player1}-${pw.player2}`} pw={pw} index={i} />
-                ))}
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              {sortedPairs.map((pw, i) => (
+                <MatchupCard
+                  key={`${pw.player1}-${pw.player2}`}
+                  pw={pw}
+                  index={i}
+                  onClick={() => {
+                    setSelectedP1(pw.player1);
+                    setSelectedP2(pw.player2);
+                    window.scrollTo({ top: 0, behavior: "smooth" });
+                  }}
+                />
+              ))}
             </div>
           )}
         </div>
 
-        {/* Player win records against all others */}
+        {/* ── Overall Pair Win Record ──────────────────────────────────────── */}
         <div className="felt-card rounded-lg overflow-hidden">
-          <div className="px-5 py-4" style={{ borderBottom: "1px solid oklch(0.22 0.03 155)" }}>
+          <div
+            className="px-5 py-4"
+            style={{ borderBottom: "1px solid oklch(0.22 0.03 155)" }}
+          >
             <div className="flex items-center gap-2">
               <Users2 size={15} style={{ color: "oklch(0.78 0.15 85)" }} />
-              <h2 className="font-semibold" style={{ fontFamily: "'Playfair Display', serif", color: "oklch(0.92 0.015 85)" }}>
+              <h2
+                className="font-semibold"
+                style={{
+                  fontFamily: "'Playfair Display', serif",
+                  color: "oklch(0.92 0.015 85)",
+                }}
+              >
                 Overall Pair Win Record
               </h2>
             </div>
             <p className="text-xs mt-0.5" style={{ color: "oklch(0.50 0.02 85)" }}>
-              Combined win record when playing alongside any other player
+              Combined W–L record when playing alongside any other player
             </p>
           </div>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr style={{ borderBottom: "1px solid oklch(0.18 0.02 155)" }}>
-                  {["#", "Player", "Pair Wins", "Pair Losses", "Pair Win Rate"].map((h) => (
-                    <th key={h} className="px-5 py-3 text-left text-xs uppercase tracking-wider" style={{ color: "oklch(0.45 0.02 85)" }}>
+                  {["#", "Player", "W", "L", "Win Rate"].map((h) => (
+                    <th
+                      key={h}
+                      className="px-5 py-3 text-left text-xs uppercase tracking-wider"
+                      style={{ color: "oklch(0.45 0.02 85)" }}
+                    >
                       {h}
                     </th>
                   ))}
                 </tr>
               </thead>
               <tbody>
-                {playerWinRecords.map((r, i) => (
+                {playerPairRecords.map((r, i) => (
                   <tr
                     key={r.player}
                     className="transition-colors hover:bg-[oklch(0.15_0.018_155)]"
-                    style={{ borderBottom: i < playerWinRecords.length - 1 ? "1px solid oklch(0.15 0.018 155)" : "none" }}
+                    style={{
+                      borderBottom:
+                        i < playerPairRecords.length - 1
+                          ? "1px solid oklch(0.15 0.018 155)"
+                          : "none",
+                    }}
                   >
-                    <td className="px-5 py-3 rank-number font-bold text-base" style={{ color: i === 0 ? "oklch(0.78 0.15 85)" : "oklch(0.40 0.02 85)" }}>
+                    <td
+                      className="px-5 py-3 rank-number font-bold text-base"
+                      style={{
+                        color:
+                          i === 0 ? "oklch(0.78 0.15 85)" : "oklch(0.40 0.02 85)",
+                      }}
+                    >
                       {i + 1}
                     </td>
                     <td className="px-5 py-3">
                       <div className="flex items-center gap-2">
-                        <div className="w-2.5 h-2.5 rounded-full" style={{ background: getPlayerColor(r.player) }} />
-                        <span className="font-medium" style={{ color: "oklch(0.88 0.015 85)" }}>{r.player}</span>
+                        <div
+                          className="w-2.5 h-2.5 rounded-full"
+                          style={{ background: getPlayerColor(r.player) }}
+                        />
+                        <span
+                          className="font-medium"
+                          style={{ color: "oklch(0.88 0.015 85)" }}
+                        >
+                          {r.player}
+                        </span>
                       </div>
                     </td>
-                    <td className="px-5 py-3 rank-number font-semibold" style={{ color: "oklch(0.78 0.15 85)" }}>{r.wins}</td>
-                    <td className="px-5 py-3 rank-number" style={{ color: "oklch(0.60 0.02 85)" }}>{r.losses}</td>
+                    <td
+                      className="px-5 py-3 rank-number font-semibold"
+                      style={{ color: "oklch(0.78 0.15 85)" }}
+                    >
+                      {r.wins}
+                    </td>
+                    <td
+                      className="px-5 py-3 rank-number"
+                      style={{ color: "oklch(0.55 0.02 85)" }}
+                    >
+                      {r.losses}
+                    </td>
                     <td className="px-5 py-3">
                       <div className="flex items-center gap-2">
-                        <div className="w-16 h-1.5 rounded-full overflow-hidden" style={{ background: "oklch(0.18 0.02 155)" }}>
-                          <div className="h-full rounded-full" style={{ width: `${r.winPct}%`, background: getPlayerColor(r.player) }} />
+                        <div
+                          className="w-20 h-1.5 rounded-full overflow-hidden"
+                          style={{ background: "oklch(0.18 0.02 155)" }}
+                        >
+                          <div
+                            className="h-full rounded-full"
+                            style={{
+                              width: `${r.winPct}%`,
+                              background: getPlayerColor(r.player),
+                            }}
+                          />
                         </div>
-                        <span className="rank-number text-xs" style={{ color: "oklch(0.65 0.015 85)" }}>{r.winPct}%</span>
+                        <span
+                          className="rank-number text-xs"
+                          style={{ color: "oklch(0.65 0.015 85)" }}
+                        >
+                          {r.winPct}%
+                        </span>
                       </div>
                     </td>
                   </tr>

--- a/website/client/src/pages/PlayerProfilePage.tsx
+++ b/website/client/src/pages/PlayerProfilePage.tsx
@@ -1,0 +1,494 @@
+/*
+ * PlayerProfilePage — Dark Casino / Art Deco Design System
+ * Per-player deep-dive: career overview, tournament history table,
+ * rating progression, consistency trend, milestone timeline
+ */
+import { useEffect, useState } from "react";
+import { useParams, Link } from "wouter";
+import Layout from "@/components/Layout";
+import { motion } from "framer-motion";
+import {
+  LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
+  BarChart, Bar, Cell, ReferenceLine,
+} from "recharts";
+import {
+  fetchGameData, getPlayerColor, type GameData, type TournamentSummary,
+  TOURNAMENT_TYPE_LABELS, TOURNAMENT_TYPE_COLORS,
+} from "@/lib/gameData";
+import { Trophy, Zap, Crown, Egg, Flame, Skull, Target, TrendingUp, ArrowLeft, Star } from "lucide-react";
+
+const GOLD = "oklch(0.78 0.15 85)";
+const DIM = "oklch(0.55 0.02 85)";
+const CARD_BG = "oklch(0.13 0.016 155)";
+const BORDER = "oklch(0.22 0.03 155)";
+
+function SectionHeader({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <div className="px-5 py-4" style={{ borderBottom: `1px solid ${BORDER}` }}>
+      <h2 className="text-base font-semibold tracking-wide" style={{ color: GOLD, fontFamily: "'Playfair Display', serif" }}>
+        {title}
+      </h2>
+      {subtitle && <p className="text-xs mt-0.5" style={{ color: DIM }}>{subtitle}</p>}
+    </div>
+  );
+}
+
+const CORE_PLAYERS = ["Akash", "Nats", "Prateek", "Abhi", "Ani", "Naati", "Skanda"];
+
+export default function PlayerProfilePage() {
+  const params = useParams<{ player: string }>();
+  const playerName = decodeURIComponent(params.player ?? "");
+
+  const [data, setData] = useState<GameData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetchGameData()
+      .then(d => { setData(d); setLoading(false); })
+      .catch(() => { setError(true); setLoading(false); });
+  }, []);
+
+  if (loading) {
+    return (
+      <Layout>
+        <div className="flex items-center justify-center h-64" style={{ color: DIM }}>
+          Loading profile…
+        </div>
+      </Layout>
+    );
+  }
+  if (error || !data) {
+    return (
+      <Layout>
+        <div className="flex items-center justify-center h-64" style={{ color: "oklch(0.65 0.15 20)" }}>
+          Failed to load data.
+        </div>
+      </Layout>
+    );
+  }
+
+  const { careerStats, allTimeStats, ratingHistory, tournamentSummary, tournamentSnapshots } = data;
+
+  const cs = careerStats[playerName];
+  const ats = allTimeStats.find(s => s.player === playerName);
+
+  if (!cs || !ats) {
+    return (
+      <Layout>
+        <div className="flex flex-col items-center justify-center h-64 gap-4">
+          <div style={{ color: DIM }}>Player "{playerName}" not found.</div>
+          <Link href="/career-stats">
+            <span className="text-sm underline" style={{ color: GOLD }}>← Back to Career Stats</span>
+          </Link>
+        </div>
+      </Layout>
+    );
+  }
+
+  const playerColor = getPlayerColor(playerName);
+
+  // Tournament history: all tournaments this player participated in
+  const playerTourneys = tournamentSummary
+    .filter(t => t.players.includes(playerName))
+    .map(t => {
+      const ps = t.playerStats.find(s => s.Player === playerName);
+      const snap = tournamentSnapshots[t.id]?.[playerName];
+      const rank = t.playerStats
+        .slice()
+        .sort((a, b) => b.TotalPoints - a.TotalPoints)
+        .findIndex(s => s.Player === playerName) + 1;
+      return {
+        id: t.id,
+        displayName: t.displayName,
+        type: t.type,
+        totalGames: t.totalGames,
+        winner: t.winner,
+        wins: ps?.Wins ?? 0,
+        totalPoints: ps?.TotalPoints ?? 0,
+        winPct: ps?.WinPercentage ?? 0,
+        avgPoints: ps?.AvgPoints ?? 0,
+        rank,
+        ratingChange: snap?.ratingChange ?? 0,
+        ratingAfter: snap?.ratingAfter ?? 0,
+        fivplesThisTourney: snap?.fivplesThisTourney ?? 0,
+        tenplesThisTourney: snap?.tenplesThisTourney ?? 0,
+        fiveMottesThisTourney: snap?.fiveMottesThisTourney ?? 0,
+      };
+    });
+
+  // Short label helper: "Championship #3" -> "C#3", "Mini Championship #2" -> "MC#2",
+  // "Tiny Championship #7" -> "TC#7", "International Friendly #1" -> "IF#1"
+  function shortLabel(displayName: string): string {
+    return displayName
+      .replace("International Friendly", "IF")
+      .replace("Tiny Championship", "TC")
+      .replace("Mini Championship", "MC")
+      .replace("Championship", "C")
+      .replace(" #", "#");
+  }
+
+  // Rating progression for this player — keyed by short tournament label
+  // ratingHistory[0] is the baseline (all 1000), ratingHistory[n] is after tournamentSummary[n-1]
+  const ratingProgression = ratingHistory
+    .filter(r => r[playerName] !== undefined)
+    .map((r) => {
+      const n = r.tournament as number;
+      const tourney = n > 0 ? tournamentSummary[n - 1] : null;
+      return {
+        tournament: tourney ? shortLabel(tourney.displayName) : "Start",
+        rating: r[playerName] as number,
+      };
+    });
+
+  // Win rate per tournament — use short label as x-axis key
+  const winRateByTourney = playerTourneys.map((t) => ({
+    name: shortLabel(t.displayName),
+    winRate: t.winPct,
+    displayName: t.displayName,
+  }));
+
+  // Best and worst tournaments
+  const sortedByWinPct = [...playerTourneys].sort((a, b) => b.winPct - a.winPct);
+  const bestTourney = sortedByWinPct[0];
+  const worstTourney = sortedByWinPct[sortedByWinPct.length - 1];
+  const bestRatingGain = [...playerTourneys].sort((a, b) => b.ratingChange - a.ratingChange)[0];
+  const tourneyWins = playerTourneys.filter(t => t.winner === playerName).length;
+
+  const tooltipStyle = {
+    backgroundColor: "oklch(0.14 0.018 155)",
+    border: `1px solid ${BORDER}`,
+    borderRadius: "6px",
+    color: "oklch(0.88 0.02 85)",
+    fontSize: "12px",
+  };
+
+  return (
+    <Layout>
+      <div className="p-4 md:p-6 space-y-5 max-w-5xl mx-auto">
+
+        {/* Back link */}
+        <Link href="/career-stats">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            className="flex items-center gap-1.5 text-sm cursor-pointer w-fit"
+            style={{ color: DIM }}
+            whileHover={{ color: GOLD }}
+          >
+            <ArrowLeft size={14} />
+            Career Stats
+          </motion.div>
+        </Link>
+
+        {/* Player header */}
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="rounded-lg p-6"
+          style={{ background: CARD_BG, border: `1px solid ${BORDER}` }}
+        >
+          <div className="flex flex-col md:flex-row md:items-center gap-4">
+            {/* Avatar */}
+            <div
+              className="w-16 h-16 rounded-full flex items-center justify-center text-2xl font-bold flex-shrink-0"
+              style={{
+                background: `${playerColor}22`,
+                border: `2px solid ${playerColor}`,
+                color: playerColor,
+                fontFamily: "'Playfair Display', serif",
+              }}
+            >
+              {playerName[0]}
+            </div>
+            {/* Name + quick stats */}
+            <div className="flex-1">
+              <h1
+                className="text-2xl md:text-3xl font-bold"
+                style={{ color: playerColor, fontFamily: "'Playfair Display', serif" }}
+              >
+                {playerName}
+              </h1>
+              <div className="flex flex-wrap gap-4 mt-2">
+                <span className="text-sm" style={{ color: DIM }}>
+                  <span style={{ color: GOLD, fontWeight: 600 }}>{cs.careerGames.toLocaleString()}</span> career rounds
+                </span>
+                <span className="text-sm" style={{ color: DIM }}>
+                  <span style={{ color: GOLD, fontWeight: 600 }}>{playerTourneys.length}</span> tournaments
+                </span>
+                <span className="text-sm" style={{ color: DIM }}>
+                  <span style={{ color: GOLD, fontWeight: 600 }}>{tourneyWins}</span> tournament wins
+                </span>
+                <span className="text-sm" style={{ color: DIM }}>
+                  Current rating: <span style={{ color: GOLD, fontWeight: 600 }}>{ratingProgression[ratingProgression.length - 1]?.rating ?? "—"}</span>
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Stat pills */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-5">
+            {[
+              { label: "Win Rate", value: `${cs.winPct}%`, icon: TrendingUp },
+              { label: "Avg Points", value: ats.avgPoints.toFixed(1), icon: Star },
+              { label: "Best Win Streak", value: `${cs.bestWinStreak}`, icon: Flame },
+              { label: "Worst Loss Streak", value: `${cs.worstLossStreak}`, icon: Skull },
+              { label: "Fivples ⚡", value: `${cs.numFivles}`, icon: Zap },
+              { label: "Tenples 👑", value: `${cs.numTenples}`, icon: Crown },
+              { label: "FiveMottes 🥚", value: `${cs.fiveMottes}`, icon: Egg },
+              { label: "Bid Win Rate", value: cs.bidWinRate !== null ? `${cs.bidWinRate.toFixed(1)}%` : "—", icon: Target },
+            ].map(({ label, value, icon: Icon }) => (
+              <div
+                key={label}
+                className="rounded p-3"
+                style={{ background: "oklch(0.10 0.012 155)", border: `1px solid oklch(0.18 0.022 155)` }}
+              >
+                <div className="flex items-center gap-1.5 mb-1">
+                  <Icon size={12} style={{ color: DIM }} />
+                  <span className="text-xs" style={{ color: DIM }}>{label}</span>
+                </div>
+                <div className="text-lg font-bold" style={{ color: playerColor, fontFamily: "'Playfair Display', serif" }}>
+                  {value}
+                </div>
+              </div>
+            ))}
+          </div>
+        </motion.div>
+
+        {/* Best / Worst highlights */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {[
+            {
+              label: "Best Tournament",
+              tourney: bestTourney,
+              stat: `${bestTourney?.winPct}% win rate`,
+              color: "oklch(0.75 0.18 155)",
+              icon: Trophy,
+            },
+            {
+              label: "Worst Tournament",
+              tourney: worstTourney,
+              stat: `${worstTourney?.winPct}% win rate`,
+              color: "oklch(0.65 0.12 20)",
+              icon: Skull,
+            },
+            {
+              label: "Biggest Rating Gain",
+              tourney: bestRatingGain,
+              stat: `+${bestRatingGain?.ratingChange} pts`,
+              color: GOLD,
+              icon: TrendingUp,
+            },
+          ].map(({ label, tourney, stat, color, icon: Icon }, i) => (
+            <motion.div
+              key={label}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: i * 0.07 }}
+              className="rounded-lg p-4"
+              style={{ background: CARD_BG, border: `1px solid ${BORDER}` }}
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <Icon size={14} style={{ color }} />
+                <span className="text-xs uppercase tracking-wider" style={{ color: DIM }}>{label}</span>
+              </div>
+              <div className="font-semibold text-sm" style={{ color }}>
+                {tourney?.displayName ?? "—"}
+              </div>
+              <div className="text-xs mt-0.5" style={{ color: DIM }}>{stat}</div>
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Charts: Rating progression + Win rate trend */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.2 }}
+            className="rounded-lg overflow-hidden"
+            style={{ background: CARD_BG, border: `1px solid ${BORDER}` }}
+          >
+            <SectionHeader title="Rating Progression" subtitle="Elo rating after each tournament" />
+            <div className="p-4" style={{ height: 200 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={ratingProgression} margin={{ top: 5, right: 10, left: -20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="oklch(0.18 0.02 155)" />
+                  <XAxis dataKey="tournament" tick={{ fill: DIM, fontSize: 9 }} axisLine={false} tickLine={false} angle={-40} textAnchor="end" height={40} interval="preserveStartEnd" />
+                  <YAxis tick={{ fill: DIM, fontSize: 10 }} domain={["auto", "auto"]} axisLine={false} tickLine={false} />
+                  <Tooltip contentStyle={tooltipStyle} formatter={(v: number) => [v, "Rating"]} />
+                  <ReferenceLine y={1000} stroke="oklch(0.35 0.03 155)" strokeDasharray="4 4" />
+                  <Line type="monotone" dataKey="rating" stroke={playerColor} strokeWidth={2} dot={false} activeDot={{ r: 4 }} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.25 }}
+            className="rounded-lg overflow-hidden"
+            style={{ background: CARD_BG, border: `1px solid ${BORDER}` }}
+          >
+            <SectionHeader title="Win Rate by Tournament" subtitle="Win % in each tournament played" />
+            <div className="p-4" style={{ height: 200 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={winRateByTourney} margin={{ top: 5, right: 10, left: -20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="oklch(0.18 0.02 155)" />
+                  <XAxis dataKey="name" tick={{ fill: DIM, fontSize: 9 }} axisLine={false} tickLine={false} angle={-40} textAnchor="end" height={40} interval="preserveStartEnd" />
+                  <YAxis tick={{ fill: DIM, fontSize: 10 }} domain={[0, 100]} axisLine={false} tickLine={false} />
+                  <Tooltip
+                    contentStyle={tooltipStyle}
+                    formatter={(v: number, _: string, props: { payload?: { displayName?: string } }) => [
+                      `${v}%`,
+                      props.payload?.displayName ?? "Win Rate",
+                    ]}
+                  />
+                  <ReferenceLine y={50} stroke="oklch(0.35 0.03 155)" strokeDasharray="4 4" />
+                  <Bar dataKey="winRate" radius={[3, 3, 0, 0]}>
+                    {winRateByTourney.map((entry, i) => (
+                      <Cell
+                        key={i}
+                        fill={entry.winRate >= 55 ? playerColor : entry.winRate >= 50 ? `${playerColor}99` : "oklch(0.40 0.08 20)"}
+                      />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </motion.div>
+        </div>
+
+        {/* Tournament history table */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.3 }}
+          className="rounded-lg overflow-hidden"
+          style={{ background: CARD_BG, border: `1px solid ${BORDER}` }}
+        >
+          <SectionHeader title="Tournament History" subtitle={`${playerTourneys.length} tournaments played`} />
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr style={{ borderBottom: `1px solid ${BORDER}` }}>
+                  {["Tournament", "Type", "Finish", "Rounds", "Wins", "Win %", "Avg Pts", "Rating Δ", "Milestones"].map(h => (
+                    <th key={h} className="px-3 py-3 text-left text-xs font-semibold uppercase tracking-wider whitespace-nowrap" style={{ color: DIM }}>
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {playerTourneys.map((t, i) => (
+                  <motion.tr
+                    key={t.id}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    transition={{ delay: 0.35 + i * 0.02 }}
+                    style={{ borderBottom: i < playerTourneys.length - 1 ? `1px solid oklch(0.15 0.018 155)` : "none" }}
+                    onMouseEnter={e => (e.currentTarget.style.background = "oklch(0.15 0.018 155)")}
+                    onMouseLeave={e => (e.currentTarget.style.background = "transparent")}
+                  >
+                    <td className="px-3 py-2.5">
+                      <Link href={`/tournaments/${t.id}`}>
+                        <span
+                          className="font-medium text-xs cursor-pointer hover:underline"
+                          style={{ color: t.winner === playerName ? GOLD : "oklch(0.80 0.015 85)" }}
+                        >
+                          {t.winner === playerName && <Trophy size={10} className="inline mr-1" style={{ color: GOLD }} />}
+                          {t.displayName}
+                        </span>
+                      </Link>
+                    </td>
+                    <td className="px-3 py-2.5">
+                      <span
+                        className="text-xs px-1.5 py-0.5 rounded"
+                        style={{
+                          background: `${TOURNAMENT_TYPE_COLORS[t.type]}22`,
+                          color: TOURNAMENT_TYPE_COLORS[t.type],
+                          border: `1px solid ${TOURNAMENT_TYPE_COLORS[t.type]}44`,
+                        }}
+                      >
+                        {TOURNAMENT_TYPE_LABELS[t.type].replace(" Championship", "").replace("International ", "")}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2.5">
+                      <span
+                        className="font-semibold text-xs"
+                        style={{ color: t.rank === 1 ? GOLD : t.rank === 2 ? "oklch(0.75 0.05 85)" : DIM }}
+                      >
+                        {t.rank === 1 ? "🥇" : t.rank === 2 ? "🥈" : t.rank === 3 ? "🥉" : `#${t.rank}`}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2.5 text-xs" style={{ color: "oklch(0.75 0.015 85)" }}>{t.totalGames}</td>
+                    <td className="px-3 py-2.5 text-xs" style={{ color: "oklch(0.75 0.015 85)" }}>{t.wins}</td>
+                    <td className="px-3 py-2.5">
+                      <span
+                        className="text-xs font-medium"
+                        style={{ color: t.winPct >= 55 ? "oklch(0.75 0.18 155)" : t.winPct >= 50 ? GOLD : "oklch(0.65 0.12 20)" }}
+                      >
+                        {t.winPct}%
+                      </span>
+                    </td>
+                    <td className="px-3 py-2.5 text-xs" style={{ color: "oklch(0.75 0.015 85)" }}>{t.avgPoints.toFixed(1)}</td>
+                    <td className="px-3 py-2.5">
+                      <span
+                        className="text-xs font-medium"
+                        style={{ color: t.ratingChange > 0 ? "oklch(0.75 0.18 155)" : t.ratingChange < 0 ? "oklch(0.65 0.12 20)" : DIM }}
+                      >
+                        {t.ratingChange > 0 ? "+" : ""}{t.ratingChange}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2.5">
+                      <div className="flex items-center gap-1 text-xs">
+                        {t.tenplesThisTourney > 0 && (
+                          <span title="Tenple">👑{t.tenplesThisTourney > 1 ? `×${t.tenplesThisTourney}` : ""}</span>
+                        )}
+                        {t.fivplesThisTourney > 0 && (
+                          <span title="Fivple">⚡{t.fivplesThisTourney > 1 ? `×${t.fivplesThisTourney}` : ""}</span>
+                        )}
+                        {t.fiveMottesThisTourney > 0 && (
+                          <span title="FiveMotte">🥚{t.fiveMottesThisTourney > 1 ? `×${t.fiveMottesThisTourney}` : ""}</span>
+                        )}
+                      </div>
+                    </td>
+                  </motion.tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </motion.div>
+
+        {/* Player switcher */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.5 }}
+          className="rounded-lg p-4"
+          style={{ background: CARD_BG, border: `1px solid ${BORDER}` }}
+        >
+          <div className="text-xs uppercase tracking-wider mb-3" style={{ color: DIM }}>Other Players</div>
+          <div className="flex flex-wrap gap-2">
+            {CORE_PLAYERS.filter(p => p !== playerName).map(p => (
+              <Link key={p} href={`/players/${encodeURIComponent(p)}`}>
+                <span
+                  className="px-3 py-1.5 rounded text-xs font-medium cursor-pointer transition-all"
+                  style={{
+                    background: `${getPlayerColor(p)}18`,
+                    border: `1px solid ${getPlayerColor(p)}44`,
+                    color: getPlayerColor(p),
+                  }}
+                >
+                  {p}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </motion.div>
+
+      </div>
+    </Layout>
+  );
+}

--- a/website/client/src/pages/TournamentDetailPage.tsx
+++ b/website/client/src/pages/TournamentDetailPage.tsx
@@ -915,7 +915,69 @@ export default function TournamentDetailPage() {
               </div>
             )}
 
-            {/* ── 8. Post-Tournament Leaderboard ───────────────────────────── */}
+            {/* ── 8. Milestone Achievements ──────────────────────────────── */}
+            {(() => {
+              // Collect per-tournament milestone achievements from snapshot deltas
+              const achievements: { player: string; type: "fivple" | "tenple" | "fivemotte"; count: number }[] = [];
+              if (snapshot) {
+                for (const [player, snap] of Object.entries(snapshot)) {
+                  if (snap.tenplesThisTourney > 0)
+                    achievements.push({ player, type: "tenple", count: snap.tenplesThisTourney });
+                  if (snap.fivplesThisTourney > 0)
+                    achievements.push({ player, type: "fivple", count: snap.fivplesThisTourney });
+                  if (snap.fiveMottesThisTourney > 0)
+                    achievements.push({ player, type: "fivemotte", count: snap.fiveMottesThisTourney });
+                }
+              }
+              if (achievements.length === 0) return null;
+
+              const MILESTONE_META = {
+                tenple:   { emoji: "👑", label: "Tenple",   desc: "10 consecutive wins",   bg: "oklch(0.20 0.06 85)",  border: "oklch(0.78 0.15 85)" },
+                fivple:   { emoji: "⚡", label: "Fivple",   desc: "5 consecutive wins",    bg: "oklch(0.17 0.05 155)", border: "oklch(0.55 0.14 155)" },
+                fivemotte:{ emoji: "🥚", label: "FiveMotte",desc: "5 consecutive losses", bg: "oklch(0.17 0.04 20)",  border: "oklch(0.50 0.10 20)" },
+              } as const;
+
+              return (
+                <div className="felt-card rounded-lg overflow-hidden">
+                  <SectionHeader
+                    title="Milestone Achievements"
+                    subtitle="Streaks achieved during this tournament"
+                  />
+                  <div className="p-5">
+                    <div className="flex flex-wrap gap-3">
+                      {achievements.map(({ player, type, count }, i) => {
+                        const meta = MILESTONE_META[type];
+                        return (
+                          <motion.div
+                            key={`${player}-${type}`}
+                            initial={{ opacity: 0, y: 10 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: i * 0.07 }}
+                            className="flex items-center gap-3 px-4 py-3 rounded-lg"
+                            style={{ background: meta.bg, border: `1px solid ${meta.border}` }}
+                          >
+                            <span className="text-2xl leading-none">{meta.emoji}</span>
+                            <div>
+                              <div className="flex items-center gap-1.5">
+                                <span className="font-semibold text-sm" style={{ color: getPlayerColor(player) }}>{player}</span>
+                                {count > 1 && (
+                                  <span className="text-xs font-bold px-1.5 py-0.5 rounded" style={{ background: meta.border + "44", color: meta.border }}>×{count}</span>
+                                )}
+                              </div>
+                              <div className="text-xs mt-0.5" style={{ color: "oklch(0.65 0.02 85)" }}>
+                                {meta.label} — {meta.desc}
+                              </div>
+                            </div>
+                          </motion.div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
+              );
+            })()}
+
+            {/* ── 9. Post-Tournament Leaderboard ───────────────────────────── */}
             {snapshotRows.length > 0 && (
               <div className="felt-card rounded-lg overflow-hidden">
                 <SectionHeader


### PR DESCRIPTION
Batch of data accuracy fixes and chart readability improvements.

**New pages:** Career Stats, Player Profiles

**Data accuracy:**
- Best Bid Rate hero card requires 10+ attempts
- Low-sample bid rates show attempt count instead of asterisk
- Rankings Bid Success Rate excludes players with fewer than 10 attempts

**Chart fixes:**
- Dashboard and Rankings Rating History: Y-axis zoomed to actual spread, legend shows current ratings
- Career Stats bar charts: bars were invisible (Cell vs rect bug), now show player colours
- Player Profile x-axis: C#1/MC#2/TC#7 labels instead of T2/T4/T6