### PR TITLE
feat: co-winner support for tied tournaments

### DIFF
--- a/website/client/src/lib/gameData.ts
+++ b/website/client/src/lib/gameData.ts
@@ -113,6 +113,7 @@ export interface Tournament {
   guestPlayers: string[];
   totalGames: number;
   winner: string | null;
+  winners: string[];
   playerStats: PlayerStat[];
   gameData: GameDataPoint[];
   pairwiseStats: PairwiseStat[];
@@ -135,6 +136,7 @@ export interface TournamentSummary {
   guestPlayers: string[];
   totalGames: number;
   winner: string | null;
+  winners: string[];
   playerStats: PlayerStat[];
 }
 

--- a/website/client/src/pages/CareerStatsPage.tsx
+++ b/website/client/src/pages/CareerStatsPage.tsx
@@ -77,10 +77,11 @@ export default function CareerStatsPage() {
     }
   }
 
-  // Tournament wins per player
+  // Tournament wins per player (co-winners each get a win)
   const tourneyWins: Record<string, number> = {};
   for (const t of tournamentSummary) {
-    if (t.winner) tourneyWins[t.winner] = (tourneyWins[t.winner] || 0) + 1;
+    const ws = t.winners?.length > 0 ? t.winners : (t.winner ? [t.winner] : []);
+    for (const w of ws) tourneyWins[w] = (tourneyWins[w] || 0) + 1;
   }
 
   // Build combined rows

--- a/website/client/src/pages/Home.tsx
+++ b/website/client/src/pages/Home.tsx
@@ -367,12 +367,15 @@ export default function Home() {
                     <div className="font-semibold text-sm mb-3 group-hover:text-[oklch(0.78_0.15_85)] transition-colors" style={{ color: "oklch(0.88 0.015 85)", fontFamily: "'Playfair Display', serif" }}>
                       {t.displayName}
                     </div>
-                    {t.winner && (
-                      <div className="flex items-center gap-1.5">
+                    {(t.winners?.length > 0 || t.winner) && (
+                      <div className="flex items-center gap-1 flex-wrap">
                         <Trophy size={12} style={{ color: "oklch(0.78 0.15 85)" }} />
-                        <span className="text-xs font-medium" style={{ color: getPlayerColor(t.winner) }}>
-                          {t.winner}
-                        </span>
+                        {(t.winners?.length > 1 ? t.winners : [t.winner!]).map((w, i, arr) => (
+                          <span key={w}>
+                            <span className="text-xs font-medium" style={{ color: getPlayerColor(w) }}>{w}</span>
+                            {i < arr.length - 1 && <span className="text-xs" style={{ color: "oklch(0.45 0.02 85)" }}> &amp; </span>}
+                          </span>
+                        ))}
                       </div>
                     )}
                     <div className="text-xs mt-1" style={{ color: "oklch(0.45 0.02 85)" }}>

--- a/website/client/src/pages/PlayerProfilePage.tsx
+++ b/website/client/src/pages/PlayerProfilePage.tsx
@@ -104,6 +104,7 @@ export default function PlayerProfilePage() {
         type: t.type,
         totalGames: t.totalGames,
         winner: t.winner,
+        winners: t.winners ?? [],
         wins: ps?.Wins ?? 0,
         totalPoints: ps?.TotalPoints ?? 0,
         winPct: ps?.WinPercentage ?? 0,
@@ -153,7 +154,9 @@ export default function PlayerProfilePage() {
   const bestTourney = sortedByWinPct[0];
   const worstTourney = sortedByWinPct[sortedByWinPct.length - 1];
   const bestRatingGain = [...playerTourneys].sort((a, b) => b.ratingChange - a.ratingChange)[0];
-  const tourneyWins = playerTourneys.filter(t => t.winner === playerName).length;
+  const tourneyWins = playerTourneys.filter(t =>
+    t.winners?.length > 0 ? t.winners.includes(playerName) : t.winner === playerName
+  ).length;
 
   const tooltipStyle = {
     backgroundColor: "oklch(0.14 0.018 155)",
@@ -395,9 +398,9 @@ export default function PlayerProfilePage() {
                       <Link href={`/tournaments/${t.id}`}>
                         <span
                           className="font-medium text-xs cursor-pointer hover:underline"
-                          style={{ color: t.winner === playerName ? GOLD : "oklch(0.80 0.015 85)" }}
+                          style={{ color: (t.winners?.length > 0 ? t.winners.includes(playerName) : t.winner === playerName) ? GOLD : "oklch(0.80 0.015 85)" }}
                         >
-                          {t.winner === playerName && <Trophy size={10} className="inline mr-1" style={{ color: GOLD }} />}
+                          {(t.winners?.length > 0 ? t.winners.includes(playerName) : t.winner === playerName) && <Trophy size={10} className="inline mr-1" style={{ color: GOLD }} />}
                           {t.displayName}
                         </span>
                       </Link>

--- a/website/client/src/pages/TournamentsPage.tsx
+++ b/website/client/src/pages/TournamentsPage.tsx
@@ -66,14 +66,19 @@ function TournamentCard({ t, index }: { t: TournamentSummary; index: number }) {
             <ChevronRight size={14} className="flex-shrink-0 mt-1 opacity-0 group-hover:opacity-100 transition-opacity" style={{ color: "oklch(0.78 0.15 85)" }} />
           </div>
 
-          {/* Winner */}
-          {t.winner && (
-            <div className="flex items-center gap-1.5 mb-3">
+          {/* Winner(s) */}
+          {(t.winners?.length > 0 || t.winner) && (
+            <div className="flex items-center gap-1.5 mb-3 flex-wrap">
               <Trophy size={11} style={{ color: "oklch(0.78 0.15 85)" }} />
-              <span className="text-xs font-semibold" style={{ color: getPlayerColor(t.winner) }}>
-                {t.winner}
+              {(t.winners?.length > 1 ? t.winners : [t.winner!]).map((w, i, arr) => (
+                <span key={w}>
+                  <span className="text-xs font-semibold" style={{ color: getPlayerColor(w) }}>{w}</span>
+                  {i < arr.length - 1 && <span className="text-xs" style={{ color: "oklch(0.45 0.02 85)" }}> &amp; </span>}
+                </span>
+              ))}
+              <span className="text-xs" style={{ color: "oklch(0.45 0.02 85)" }}>
+                {(t.winners?.length ?? 1) > 1 ? 'tied 1st' : 'won'}
               </span>
-              <span className="text-xs" style={{ color: "oklch(0.45 0.02 85)" }}>won</span>
             </div>
           )}
 

--- a/website/process_data.py
+++ b/website/process_data.py
@@ -199,8 +199,13 @@ def process_all_tournaments():
                     "scores": scores,
                 }
 
-        # ── Winner (top by TotalPoints) ───────────────────────────────────────
+        # ── Winner(s) — all players tied at the top TotalPoints ─────────────
         winner = player_stats[0]["Player"] if player_stats else None
+        if player_stats:
+            top_pts = player_stats[0]["TotalPoints"]
+            winners = [s["Player"] for s in player_stats if s["TotalPoints"] == top_pts]
+        else:
+            winners = []
 
         core_in_tourney = [p for p in players if p in CORE_PLAYERS]
         guests_in_tourney = [p for p in players if p not in CORE_PLAYERS]
@@ -217,6 +222,7 @@ def process_all_tournaments():
             "guestPlayers": guests_in_tourney,
             "totalGames": len(raw_df),
             "winner": winner,
+            "winners": winners,
             "playerStats": player_stats,
             "gameData": game_data,
             "pairwiseStats": pairwise,
@@ -425,8 +431,9 @@ def compute_all_time_stats(tournaments):
                 all_time[p]["wins"] += stat["Wins"]
                 all_time[p]["totalGames"] += stat["TotalGames"]
                 all_time[p]["totalPoints"] += stat["TotalPoints"]
-        if tourney["winner"] and tourney["winner"] in all_time:
-            all_time[tourney["winner"]]["tournamentWins"] += 1
+        for w in tourney.get("winners") or ([tourney["winner"]] if tourney["winner"] else []):
+            if w in all_time:
+                all_time[w]["tournamentWins"] += 1
 
     result = []
     for p, s in all_time.items():


### PR DESCRIPTION
## Summary

Adds full co-winner support so tied tournaments (like Mini Championship #6 where Akash and Skanda both finished on 3,380 pts) are displayed correctly throughout the site.

## Changes

### Pipeline (`process_data.py`)
- Detects all players tied at the top `TotalPoints` and emits a `winners[]` list alongside the existing `winner` field
- `tournamentWins` counter iterates over `winners[]` so each co-winner gets credit (Skanda now correctly shows 2 wins)

### Frontend
- **`gameData.ts`** — adds `winners: string[]` to `Tournament` and `TournamentSummary` interfaces
- **`TournamentDetailPage`** — header shows "Co-Winners" label with both names in their colours; at-a-glance summary reads "Akash and Skanda finished level on 3,380 pts — a shared victory"
- **`TournamentsPage`** — card shows "Akash & Skanda tied 1st"
- **`Home.tsx`** — recent tournament cards render all co-winners
- **`CareerStatsPage` / `PlayerProfilePage`** — win counts use `winners[]` for correct attribution