### PR TITLE
feat: History page, metadata pipeline, and tournament header redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@ See [`website/WEBSITE_README.md`](./website/WEBSITE_README.md) for full setup an
 ## Creating new tournament notebook
 1. Add tournament scores in csv format into [tourney_data/raw_scores](https://github.com/akash-suresh/three-of-spades/tree/main/tourney_data/raw_scores). (follow same naming convention for the csv file as earlier tournaments)
 2. Add tournament entry in [TOURNAMENT_LIST_CHRONOLOGICAL](https://github.com/akash-suresh/three-of-spades/blob/main/utils/constants.py#L52) list.
-3. Run the notebook — [notebook_gen.ipynb](https://github.com/akash-suresh/three-of-spades/blob/main/notebook_gen.ipynb) — to generate all tournament notebooks!
-4. Run the data pipeline to update the website:
+3. Add a row to [`tourney_data/metadata.csv`](https://github.com/akash-suresh/three-of-spades/blob/main/tourney_data/metadata.csv) with the tournament's display name, location, flag emoji, dates, and year:
+   ```
+   id,name,location,flag,dates,year
+   championship_9,My Tournament Name,London,🇬🇧,"March 1-3rd",2026
+   ```
+   The `id` must match the CSV filename (e.g. `championship_9.csv` → `championship_9`).
+4. Run the notebook — [notebook_gen.ipynb](https://github.com/akash-suresh/three-of-spades/blob/main/notebook_gen.ipynb) — to generate all tournament notebooks!
+5. Run the data pipeline to update the website:
    ```bash
    python process_data.py
    ```
    This regenerates `website/client/public/game_data.json` with updated Elo ratings, standings, pairwise stats, trio stats, bid & won, and career stats.
-5. Commit and raise a Pull request!
+6. Commit and raise a Pull request!
 
 
 ## Adding additional analysis

--- a/tourney_data/metadata.csv
+++ b/tourney_data/metadata.csv
@@ -1,0 +1,38 @@
+id,name,location,flag,dates,year
+championship_1,Peaky Blinders Inaugural Championship,London,🇬🇧,August 1-5th,2023
+championship_2,Mogu-Mogu,Coventry,🇬🇧,September 23-25th,2023
+championship_3,Skywalker-Xavi,London,🇬🇧,October 6-8th,2023
+championship_4,TBD,London,🇬🇧,October 13-15th,2023
+championship_5,Blue-Gelato,Coventry,🇬🇧,October 27-28th,2023
+championship_6,Naati's farewell,London,🇬🇧,January 18-21st,2024
+championship_7,Xchange Point,London,🇬🇧,April 4-7th,2024
+championship_8,Guruji's first farewell,London,🇬🇧,May 25-28th,2024
+mini_championship_1,Tropical-Runtz Mini Championship,Coventry,🇬🇧,October 28th,2023
+mini_championship_2,Ashirvad Mini Championship,London,🇬🇧,April 18-23rd,2024
+mini_championship_3,Nats has meetings Mini Championship,London,🇬🇧,May 26-28th,2024
+mini_championship_4,I scored for 10£ Mini Championship,London,🇬🇧,September 13-15th,2024
+mini_championship_5,The one with the Handicap,London,🇬🇧,November 23-24th,2024
+mini_championship_6,MCL Surgery,Bengaluru,🇮🇳,December 5-6th,2024
+mini_championship_7,Chinese new year,London,🇬🇧,February 1st,2025
+mini_championship_8,Queens wood,London,🇬🇧,April 12th,2025
+mini_championship_9,Abhi in London,London,🇬🇧,August 2-14th,2025
+tiny_championship_1,Yorkshire Dales,Leeds,🇬🇧,June 28-30th,2024
+tiny_championship_2,Skanda in London,London,🇬🇧,September 4-26th,2024
+tiny_championship_3,Munich has fallen,Bengaluru,🇮🇳,October 12th - November 3rd,2024
+tiny_championship_4,BA119 - Tiny on Air,Global,🌐,November 4th,2024
+tiny_championship_5,Winter Wonderland,London,🇬🇧,November 22-23rd,2024
+tiny_championship_6,One more India trip,Bengaluru,🇮🇳,December 1-27th,2024
+tiny_championship_7,New Year Bash 2025,London,🇬🇧,January 1-3rd,2025
+tiny_championship_8,Chinese new year,London,🇬🇧,January 31st,2025
+tiny_championship_9,The triple wedding trip,Bengaluru,🇮🇳,March 1-16th,2025
+tiny_championship_10,The one that was a draw,London,🇬🇧,April 11-13th,2025
+tiny_championship_11,P got a job,London,🇬🇧,July 17-20th,2025
+tiny_championship_12,Another tiny?,London,🇬🇧,July 20-22nd,2025
+tiny_championship_13,Abhi debuts in Tiny,London,🇬🇧,August 2-14th,2025
+tiny_championship_14,WW2 - No cameras allowed,London,🇬🇧,November 14-17th,2025
+tiny_championship_15,New Year Bash 2026,London,🇬🇧,January 29-31st,2026
+tiny_championship_16,Pearl Harbor Championship,London,🇬🇧,February 20-22nd,2026
+international_friendly_1,Chicken Wings,London,🇬🇧,April 18th,2024
+international_friendly_2,Blue Bottom,Canary Islands,🇪🇸,June 1-10th,2024
+international_friendly_3,Lot of twigs in a cover,Bengaluru,🇮🇳,December 17th,2024
+international_friendly_4,The 420,Bengaluru,🇮🇳,March 14th,2025

--- a/website/client/src/App.tsx
+++ b/website/client/src/App.tsx
@@ -10,7 +10,8 @@ import TournamentDetailPage from "./pages/TournamentDetailPage";
 import RankingsPage from "./pages/RankingsPage";
 import HeadToHeadPage from "./pages/HeadToHeadPage";
 import CareerStatsPage from "./pages/CareerStatsPage";
-import PlayerProfilePage from "./pages/PlayerProfilePage";
+import PlayerProfilePage from './pages/PlayerProfilePage';
+import HistoryPage from './pages/HistoryPage';
 
 function Router() {
   return (
@@ -21,6 +22,7 @@ function Router() {
       <Route path="/tournaments/:id" component={TournamentDetailPage} />
       <Route path="/head-to-head" component={HeadToHeadPage} />
       <Route path="/career-stats" component={CareerStatsPage} />
+      <Route path="/history" component={HistoryPage} />
       <Route path="/players/:player" component={PlayerProfilePage} />
       <Route path="/404" component={NotFound} />
       <Route component={NotFound} />

--- a/website/client/src/components/Layout.tsx
+++ b/website/client/src/components/Layout.tsx
@@ -5,7 +5,7 @@
  */
 import { Link, useLocation } from "wouter";
 import { cn } from "@/lib/utils";
-import { Trophy, BarChart3, Swords, LayoutDashboard, Menu, X, Medal } from "lucide-react";
+import { Trophy, BarChart3, Swords, LayoutDashboard, Menu, X, Medal, BookOpen } from "lucide-react";
 import { useState } from "react";
 
 const NAV_ITEMS = [
@@ -14,6 +14,7 @@ const NAV_ITEMS = [
   { href: "/tournaments", label: "Tournaments", icon: Trophy },
   { href: "/head-to-head", label: "Head to Head", icon: Swords },
   { href: "/career-stats", label: "Career Stats", icon: Medal },
+  { href: "/history", label: "History", icon: BookOpen },
 ];
 
 interface LayoutProps {

--- a/website/client/src/lib/gameData.ts
+++ b/website/client/src/lib/gameData.ts
@@ -138,6 +138,11 @@ export interface TournamentSummary {
   winner: string | null;
   winners: string[];
   playerStats: PlayerStat[];
+  name: string | null;
+  location: string | null;
+  flag: string | null;
+  dates: string | null;
+  year: number | null;
 }
 
 export interface PlayerRanking {

--- a/website/client/src/lib/gameData.ts
+++ b/website/client/src/lib/gameData.ts
@@ -122,6 +122,11 @@ export interface Tournament {
   bidStatsByPlayer: Record<string, { bidAttempts: number; bidWins: number; bidWinRate: number | null }>;
   hasBidderData: boolean;   // true when the source CSV had a Bidder column
   consistencyStats: Record<string, ConsistencyStat>;
+  name: string | null;
+  location: string | null;
+  flag: string | null;
+  dates: string | null;
+  year: number | null;
 }
 
 export interface TournamentSummary {

--- a/website/client/src/pages/HistoryPage.tsx
+++ b/website/client/src/pages/HistoryPage.tsx
@@ -1,0 +1,288 @@
+/*
+ * HistoryPage — Dark Casino / Art Deco Design System
+ * Rich tournament history grouped by type, matching the wiki table layout.
+ * Columns: #, Name, Location, Dates, Year, Games, Champion, 2nd, 3rd, Others
+ */
+import { useEffect, useState } from "react";
+import { Link } from "wouter";
+import { motion, AnimatePresence } from "framer-motion";
+import { ChevronDown, Trophy, MapPin, Calendar } from "lucide-react";
+import Layout from "@/components/Layout";
+import { fetchGameData, getPlayerColor, TOURNAMENT_TYPE_COLORS, type TournamentSummary, type TournamentType } from "@/lib/gameData";
+
+// ── Colour / style constants ──────────────────────────────────────────────────
+const BG       = "oklch(0.10 0.012 155)";
+const CARD_BG  = "oklch(0.13 0.018 155)";
+const BORDER   = "oklch(0.22 0.03 155)";
+const GOLD     = "oklch(0.78 0.15 85)";
+const DIM      = "oklch(0.45 0.02 85)";
+const TEXT     = "oklch(0.88 0.015 85)";
+
+const SECTIONS: { type: TournamentType; label: string; emoji: string }[] = [
+  { type: "championship",          label: "Championships",           emoji: "🏆" },
+  { type: "mini_championship",     label: "Mini Championships",      emoji: "🥇" },
+  { type: "tiny_championship",     label: "Tiny Championships",      emoji: "⚡" },
+  { type: "international_friendly",label: "International Friendlies",emoji: "🌍" },
+];
+
+// ── Podium cell ───────────────────────────────────────────────────────────────
+function PlayerCell({ name, isWinner = false }: { name: string; isWinner?: boolean }) {
+  if (!name) return <span style={{ color: DIM }}>—</span>;
+  return (
+    <Link href={`/players/${name}`}>
+      <span
+        className="cursor-pointer hover:underline font-medium"
+        style={{ color: isWinner ? getPlayerColor(name) : TEXT }}
+      >
+        {isWinner && <Trophy size={11} className="inline mr-1" style={{ color: GOLD }} />}
+        {name}
+      </span>
+    </Link>
+  );
+}
+
+// ── Section table ─────────────────────────────────────────────────────────────
+function SectionTable({ tournaments }: { tournaments: TournamentSummary[] }) {
+  // Sort descending by number (most recent first)
+  const sorted = [...tournaments].sort((a, b) => b.number - a.number);
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm border-collapse">
+        <thead>
+          <tr style={{ borderBottom: `1px solid ${BORDER}` }}>
+            {["#", "Name", "Location", "Dates", "Year", "Games", "Champion", "2nd", "3rd", "Others"].map(h => (
+              <th
+                key={h}
+                className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wider whitespace-nowrap"
+                style={{ color: DIM }}
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((t, i) => {
+            const ps = t.playerStats ?? [];
+            const winners = t.winners?.length > 0 ? t.winners : (t.winner ? [t.winner] : []);
+            const second  = ps.find(s => !winners.includes(s.Player) && ps.indexOf(s) === (winners.length));
+            const third   = ps.find(s => !winners.includes(s.Player) && ps.indexOf(s) === (winners.length + 1));
+            const others  = ps
+              .filter(s => !winners.includes(s.Player) && s !== second && s !== third)
+              .map(s => s.Player);
+
+            return (
+              <tr
+                key={t.id}
+                className="transition-colors hover:bg-[oklch(0.16_0.02_155)]"
+                style={{ borderBottom: `1px solid oklch(0.17 0.02 155)` }}
+              >
+                {/* # */}
+                <td className="px-3 py-3 font-mono text-xs" style={{ color: GOLD }}>
+                  {t.displayNumber}
+                </td>
+
+                {/* Name */}
+                <td className="px-3 py-3 min-w-[160px]">
+                  <Link href={`/tournaments/${t.id}`}>
+                    <span
+                      className="cursor-pointer hover:underline font-medium"
+                      style={{ color: TEXT, fontFamily: "'Playfair Display', serif" }}
+                    >
+                      {t.name || t.displayName}
+                    </span>
+                  </Link>
+                </td>
+
+                {/* Location */}
+                <td className="px-3 py-3 whitespace-nowrap">
+                  {t.location ? (
+                    <span className="flex items-center gap-1.5">
+                      <span className="text-base leading-none">{t.flag}</span>
+                      <span style={{ color: TEXT }}>{t.location}</span>
+                    </span>
+                  ) : (
+                    <span style={{ color: DIM }}>—</span>
+                  )}
+                </td>
+
+                {/* Dates */}
+                <td className="px-3 py-3 whitespace-nowrap text-xs" style={{ color: t.dates ? TEXT : DIM }}>
+                  {t.dates || "—"}
+                </td>
+
+                {/* Year */}
+                <td className="px-3 py-3 text-xs font-mono" style={{ color: DIM }}>
+                  {t.year ?? "—"}
+                </td>
+
+                {/* Games */}
+                <td className="px-3 py-3 text-xs font-mono" style={{ color: DIM }}>
+                  {t.totalGames}
+                </td>
+
+                {/* Champion */}
+                <td className="px-3 py-3 whitespace-nowrap">
+                  {winners.length > 0 ? (
+                    <span className="flex flex-col gap-0.5">
+                      {winners.map(w => <PlayerCell key={w} name={w} isWinner />)}
+                    </span>
+                  ) : <span style={{ color: DIM }}>—</span>}
+                </td>
+
+                {/* 2nd */}
+                <td className="px-3 py-3 whitespace-nowrap">
+                  <PlayerCell name={second?.Player ?? ""} />
+                </td>
+
+                {/* 3rd */}
+                <td className="px-3 py-3 whitespace-nowrap">
+                  <PlayerCell name={third?.Player ?? ""} />
+                </td>
+
+                {/* Others */}
+                <td className="px-3 py-3">
+                  <span className="flex flex-wrap gap-x-2 gap-y-0.5">
+                    {others.length > 0
+                      ? others.map(p => (
+                          <Link key={p} href={`/players/${p}`}>
+                            <span className="text-xs cursor-pointer hover:underline" style={{ color: DIM }}>{p}</span>
+                          </Link>
+                        ))
+                      : <span style={{ color: DIM }}>—</span>
+                    }
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Collapsible section ───────────────────────────────────────────────────────
+function Section({
+  section,
+  tournaments,
+  defaultOpen,
+}: {
+  section: typeof SECTIONS[0];
+  tournaments: TournamentSummary[];
+  defaultOpen: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const accentColor = TOURNAMENT_TYPE_COLORS[section.type];
+
+  return (
+    <div
+      className="rounded-lg overflow-hidden"
+      style={{ background: CARD_BG, border: `1px solid ${BORDER}` }}
+    >
+      {/* Header */}
+      <button
+        className="w-full flex items-center justify-between px-5 py-4 text-left transition-colors hover:bg-[oklch(0.16_0.02_155)]"
+        onClick={() => setOpen(o => !o)}
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-xl">{section.emoji}</span>
+          <span
+            className="text-base font-semibold"
+            style={{ color: accentColor, fontFamily: "'Playfair Display', serif" }}
+          >
+            {section.label}
+          </span>
+          <span
+            className="text-xs px-2 py-0.5 rounded-full font-mono"
+            style={{ background: `${accentColor}22`, color: accentColor }}
+          >
+            {tournaments.length}
+          </span>
+        </div>
+        <ChevronDown
+          size={18}
+          className="transition-transform duration-200"
+          style={{ color: DIM, transform: open ? "rotate(180deg)" : "rotate(0deg)" }}
+        />
+      </button>
+
+      {/* Table */}
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key="content"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            style={{ overflow: "hidden" }}
+          >
+            <div style={{ borderTop: `1px solid ${BORDER}` }}>
+              <SectionTable tournaments={tournaments} />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+export default function HistoryPage() {
+  const [data, setData] = useState<TournamentSummary[] | null>(null);
+
+  useEffect(() => {
+    fetchGameData().then(d => setData(d.tournamentSummary));
+  }, []);
+
+  const byType = (type: TournamentType) =>
+    (data ?? []).filter(t => t.type === type);
+
+  const totalTournaments = data?.length ?? 0;
+  const totalGames = data?.reduce((s, t) => s + t.totalGames, 0) ?? 0;
+
+  return (
+    <Layout>
+      <div className="p-6 max-w-7xl mx-auto space-y-6">
+        {/* Page header */}
+        <div className="mb-2">
+          <div className="flex items-center gap-2 mb-1">
+            <Calendar size={14} style={{ color: GOLD }} />
+            <span className="text-xs uppercase tracking-widest font-semibold" style={{ color: GOLD }}>
+              Tournament History
+            </span>
+          </div>
+          <h1
+            className="text-3xl font-bold mb-1"
+            style={{ color: TEXT, fontFamily: "'Playfair Display', serif" }}
+          >
+            The Official Record
+          </h1>
+          <p className="text-sm" style={{ color: DIM }}>
+            {totalTournaments} tournaments · {totalGames.toLocaleString()} games played
+          </p>
+        </div>
+
+        {/* Sections */}
+        {data === null ? (
+          <div className="text-center py-16" style={{ color: DIM }}>Loading…</div>
+        ) : (
+          SECTIONS.map((section, i) => {
+            const tournaments = byType(section.type);
+            if (tournaments.length === 0) return null;
+            return (
+              <Section
+                key={section.type}
+                section={section}
+                tournaments={tournaments}
+                defaultOpen={i === 0}
+              />
+            );
+          })
+        )}
+      </div>
+    </Layout>
+  );
+}

--- a/website/client/src/pages/HistoryPage.tsx
+++ b/website/client/src/pages/HistoryPage.tsx
@@ -88,7 +88,7 @@ function SectionTable({ tournaments }: { tournaments: TournamentSummary[] }) {
                   <Link href={`/tournaments/${t.id}`}>
                     <span
                       className="cursor-pointer hover:underline font-medium"
-                      style={{ color: TEXT, fontFamily: "'Playfair Display', serif" }}
+                      style={{ color: TEXT }}
                     >
                       {t.name || t.displayName}
                     </span>

--- a/website/client/src/pages/TournamentDetailPage.tsx
+++ b/website/client/src/pages/TournamentDetailPage.tsx
@@ -332,6 +332,14 @@ export default function TournamentDetailPage() {
                   >
                     {tournament.displayName}
                   </h1>
+                  {tournament.name && (
+                    <p className="text-base mt-0.5" style={{ color: "oklch(0.65 0.02 85)" }}>
+                      {tournament.flag && <span className="mr-1.5">{tournament.flag}</span>}
+                      {tournament.name}
+                      {tournament.location && <span style={{ color: "oklch(0.45 0.02 85)" }}> · {tournament.location}</span>}
+                      {tournament.dates && <span style={{ color: "oklch(0.45 0.02 85)" }}> · {tournament.dates}</span>}
+                    </p>
+                  )}
                   <div className="flex items-center gap-4 mt-2 text-sm" style={{ color: "oklch(0.55 0.02 85)" }}>
                     <span className="flex items-center gap-1"><Gamepad2 size={13} /> {tournament.totalGames} rounds</span>
                     <span className="flex items-center gap-1"><Users size={13} /> {tournament.players.length} players</span>

--- a/website/client/src/pages/TournamentDetailPage.tsx
+++ b/website/client/src/pages/TournamentDetailPage.tsx
@@ -337,7 +337,11 @@ export default function TournamentDetailPage() {
                       {tournament.flag && <span className="mr-1.5">{tournament.flag}</span>}
                       {tournament.name}
                       {tournament.location && <span style={{ color: "oklch(0.45 0.02 85)" }}> · {tournament.location}</span>}
-                      {tournament.dates && <span style={{ color: "oklch(0.45 0.02 85)" }}> · {tournament.dates}</span>}
+                      {tournament.dates && tournament.year && (
+                        <span style={{ color: "oklch(0.45 0.02 85)" }}>
+                          {" · "}{tournament.dates.replace(/[\d]+-?[\d]*(?:st|nd|rd|th)?,?\s*/g, "").trim() || tournament.dates.split(" ")[0]} {tournament.year}
+                        </span>
+                      )}
                     </p>
                   )}
                   <div className="flex items-center gap-4 mt-2 text-sm" style={{ color: "oklch(0.55 0.02 85)" }}>

--- a/website/client/src/pages/TournamentDetailPage.tsx
+++ b/website/client/src/pages/TournamentDetailPage.tsx
@@ -320,34 +320,34 @@ export default function TournamentDetailPage() {
             >
               <div className="flex flex-wrap items-start justify-between gap-4">
                 <div>
-                  <span
-                    className="inline-block text-xs px-2 py-0.5 rounded font-medium mb-2"
-                    style={{ background: typeColor + "22", color: typeColor }}
-                  >
-                    {TOURNAMENT_TYPE_LABELS[tournament.type as TournamentType]}
-                  </span>
+                  {/* Structural label: small + muted, above the name */}
+                  <p className="text-xs font-medium mb-1" style={{ color: typeColor }}>
+                    {tournament.displayName}
+                  </p>
+                  {/* Main heading: tournament name if available, else displayName */}
                   <h1
-                    className="text-2xl lg:text-3xl font-bold"
+                    className="text-2xl lg:text-3xl font-bold leading-tight"
                     style={{ fontFamily: "'Playfair Display', serif", color: "oklch(0.92 0.015 85)" }}
                   >
-                    {tournament.displayName}
+                    {tournament.name
+                      ? <>{tournament.flag && <span className="mr-2">{tournament.flag}</span>}{tournament.name}</>
+                      : tournament.displayName
+                    }
                   </h1>
-                  {tournament.name && (
-                    <p className="text-base mt-0.5" style={{ color: "oklch(0.65 0.02 85)" }}>
-                      {tournament.flag && <span className="mr-1.5">{tournament.flag}</span>}
-                      {tournament.name}
-                      {tournament.location && <span style={{ color: "oklch(0.45 0.02 85)" }}> · {tournament.location}</span>}
+                  {/* Location + date line */}
+                  {(tournament.location || tournament.year) && (
+                    <div className="flex items-center gap-2 mt-1.5 text-sm flex-wrap" style={{ color: "oklch(0.45 0.02 85)" }}>
+                      {tournament.location && <span>{tournament.location}</span>}
+                      {tournament.location && tournament.year && <span>·</span>}
                       {tournament.dates && tournament.year && (
-                        <span style={{ color: "oklch(0.45 0.02 85)" }}>
-                          {" · "}{tournament.dates.replace(/[\d]+-?[\d]*(?:st|nd|rd|th)?,?\s*/g, "").trim() || tournament.dates.split(" ")[0]} {tournament.year}
-                        </span>
+                        <span>{tournament.dates.replace(/[\d]+-?[\d]*(?:st|nd|rd|th)?,?\s*/g, "").trim() || tournament.dates.split(" ")[0]} {tournament.year}</span>
                       )}
-                    </p>
+                    </div>
                   )}
-                  <div className="flex items-center gap-4 mt-2 text-sm" style={{ color: "oklch(0.55 0.02 85)" }}>
+                  {/* Stats line */}
+                  <div className="flex items-center gap-4 mt-1.5 text-sm" style={{ color: "oklch(0.55 0.02 85)" }}>
                     <span className="flex items-center gap-1"><Gamepad2 size={13} /> {tournament.totalGames} rounds</span>
                     <span className="flex items-center gap-1"><Users size={13} /> {tournament.players.length} players</span>
-                    <span className="flex items-center gap-1"><Star size={13} /> ×{tournament.weight} weight</span>
                   </div>
                 </div>
                 {(tournament.winners?.length > 0 || tournament.winner) && (

--- a/website/client/src/pages/TournamentsPage.tsx
+++ b/website/client/src/pages/TournamentsPage.tsx
@@ -62,6 +62,12 @@ function TournamentCard({ t, index }: { t: TournamentSummary; index: number }) {
               >
                 {t.displayName}
               </h3>
+              {t.name && (
+                <p className="text-xs mt-0.5 leading-snug" style={{ color: "oklch(0.50 0.02 85)" }}>
+                  {t.flag && <span className="mr-1">{t.flag}</span>}
+                  {t.name}
+                </p>
+              )}
             </div>
             <ChevronRight size={14} className="flex-shrink-0 mt-1 opacity-0 group-hover:opacity-100 transition-opacity" style={{ color: "oklch(0.78 0.15 85)" }} />
           </div>


### PR DESCRIPTION
## Summary

### New feature: Tournament History page
- Added `/history` route with four collapsible sections (Championships, Mini, Tiny, Friendlies)
- Rich table per section: #, Name, Location, Dates, Year, Games, Champion (🏆), 2nd, 3rd, Others
- All names link to tournament detail / player profile pages

### New data: `tourney_data/metadata.csv`
- Canonical source for tournament names, locations, country flags, dates, and years
- 37 rows covering all tournaments
- `process_data.py` now loads and attaches metadata to every tournament in `game_data.json`

### Tournament detail page header redesign (Option B)
- Tournament name (e.g. *Munich has fallen*) promoted to main `h1` heading with flag
- `displayName` (e.g. *Tiny Championship #3*) demoted to small coloured label above
- Location + month/year on one muted line; rounds + players on a second line
- Removes visual crowding from the previous 4-line stacked layout

### Tournaments list cards
- Each card now shows the tournament name + flag as a subtitle below the display name

### README
- Step 3 in *Creating a new tournament* now instructs adding a row to `metadata.csv`

## Files changed
- `tourney_data/metadata.csv` (new)
- `website/process_data.py`
- `website/client/src/lib/gameData.ts`
- `website/client/src/pages/HistoryPage.tsx` (new)
- `website/client/src/pages/TournamentDetailPage.tsx`
- `website/client/src/pages/TournamentsPage.tsx`
- `website/client/src/App.tsx`
- `website/client/src/components/Layout.tsx`
- `README.md`