### PR TITLE
Add AGENTS.md score-update guide and fix stale docs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,112 @@
+# AGENT.md — Updating tournament scores
+
+Guide for an AI agent asked to **add a new tournament** or **fix scores in an existing
+one**. Read this plus the file table below; you do not need to read the notebooks.
+
+## What this repo is
+
+A card-game (3 of Spades) record keeper. Raw per-hand scores live as CSVs; a Python
+pipeline derives Elo ratings, standings, and head-to-head stats into a JSON file that a
+React dashboard renders. Jupyter notebooks are a separate, per-tournament analysis view.
+
+## The data contract
+
+One CSV per tournament: `tourney_data/raw_scores/<type>_<n>.csv`. One **row per hand**.
+
+```
+Bidder,Nats,Prateek,Akash,Discard,Margin
+Prateek,200,0,220,25,30
+```
+
+- **Player columns** — any column that is *not* `Bidder`, `Discard`, `Margin`, or
+  `Game ID`. Player names come from the CSV header, so they must be spelled
+  **identically to every other CSV** (`Akash`, `Prateek`, `Nats`, `Abhi`, `Ani`,
+  `Naati`). A typo silently creates a new player.
+- **A score `> 0` means that player was on the winning side of that hand**; `0` means
+  they lost it. That is the only thing the win-rate and pairwise math looks at.
+- **`Bidder`, `Discard`, `Margin` are optional** and vary by era — `championship_1.csv`
+  has none of them, `mini_championship_9.csv` has `Bidder` + `Margin` but no `Discard`.
+  Match the shape of the tournament you are editing; don't add columns to old files.
+- `Bidder` must be one of the player column names. Its presence is what enables named
+  bid stats (`hasBidderData`); without it the pipeline falls back to a heuristic.
+- **Tournament winner is derived, never written down**: highest total points wins. Ties
+  produce a `winners` array. Do not try to record a winner anywhere.
+
+Valid types: `championship`, `mini_championship`, `tiny_championship`,
+`international_friendly`. Championship and Friendly carry Elo weight 1.0; Mini and Tiny
+carry 0.75.
+
+## Files to touch
+
+| File | Change |
+|---|---|
+| `tourney_data/raw_scores/<type>_<n>.csv` | The scores themselves |
+| `tourney_data/metadata.csv` | One row: `id,name,location,flag,dates,year` — `id` **must** equal the CSV filename without `.csv` |
+| `utils/constants.py` → `TOURNAMENT_LIST_CHRONOLOGICAL` | Append `(TournamentTypes.X, n)` **in chronological order** |
+
+That is the whole change for a new tournament — see commit `c2b14e6` ("added tiny 17"),
+which touched exactly these three files. For a **score correction**, only the CSV changes.
+
+Ordering in `TOURNAMENT_LIST_CHRONOLOGICAL` is not cosmetic: Elo is computed by walking
+that list in sequence, so inserting a tournament in the wrong slot silently changes every
+subsequent rating.
+
+## Steps
+
+1. Write/edit the CSV. Keep the header identical to the tournament's existing shape.
+2. Add the `metadata.csv` row (new tournaments only). Quote `dates` if it contains a
+   comma: `"March 1-3rd"`.
+3. Append to `TOURNAMENT_LIST_CHRONOLOGICAL` in `utils/constants.py` (new tournaments only).
+4. Verify (below).
+5. Commit. Do **not** open a PR unless asked.
+
+## Verify
+
+```bash
+pip install -r requirements.txt      # numpy, pandas, matplotlib
+python3 website/process_data.py      # ~4s
+```
+
+Expect a per-tournament line, then final rankings. Confirm your tournament appears with
+the right player count, hand count, and winner:
+
+```
+Processed tiny_championship_17: 3 players, 69 games, winner: Akash
+...
+Total tournaments: 38
+```
+
+Sanity check that the total went up by one, and that Elo for uninvolved players did not
+move if you only appended to the end of the list.
+
+Consistency check for metadata drift:
+
+```bash
+python3 -c "
+import csv,os
+ids={r['id'] for r in csv.DictReader(open('tourney_data/metadata.csv'))}
+files={f[:-4] for f in os.listdir('tourney_data/raw_scores') if f.endswith('.csv')}
+print('missing csv:', sorted(ids-files)); print('missing metadata:', sorted(files-ids))
+"
+```
+
+Both lists must be empty.
+
+## Traps
+
+- **Run `website/process_data.py`, not the root `process_data.py`.** The root copy is
+  stale and dead: it hardcodes `/home/ubuntu/...` paths and carries its own frozen
+  tournament list that stops at `international_friendly_4`. `netlify.toml` builds with
+  `python3 website/process_data.py`. (The README still points at the root file — it is
+  wrong.)
+- **`game_data.json` is generated, gitignored, and must not be committed.** Netlify
+  regenerates it on every deploy. If you want to inspect it, write it elsewhere:
+  `python3 website/process_data.py /tmp/game_data.json`.
+- **Regenerating notebooks is optional and expensive.** `notebook_gen.ipynb` re-executes
+  *every* tournament notebook from `template.ipynb`, rewriting ~40 files of ~250KB each.
+  Only run it when `template.ipynb` itself changed. A score update does not need it.
+- **The `Players` enum in `utils/constants.py` is currently unused by any code path.**
+  Player identity comes from CSV headers. Adding a new player there changes nothing
+  functionally — but update it anyway so the enum and `tourney_data/nomenclature.md`
+  stay honest.
+- Blank score cells coerce to `0`, which reads as "lost this hand". Write explicit `0`s.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENT.md — Updating tournament scores
+# AGENTS.md — Updating tournament scores
 
 Guide for an AI agent asked to **add a new tournament** or **fix scores in an existing
 one**. Read this plus the file table below; you do not need to read the notebooks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -4,25 +4,32 @@
 
 ## Championship Tracker Website
 A live web dashboard tracking Elo ratings, tournament standings, head-to-head stats, and more.
-The site is powered by [`process_data.py`](./process_data.py), which imports directly from `utils/` and outputs the data file consumed by the website.
+The site is powered by [`website/process_data.py`](./website/process_data.py), which imports directly from `utils/` and outputs the data file consumed by the website.
 See [`website/WEBSITE_README.md`](./website/WEBSITE_README.md) for full setup and local development instructions.
+
+> **Adding scores?** [`AGENTS.md`](./AGENTS.md) is the detailed guide — CSV column
+> contract, the exact files to touch, how to verify, and the known traps. Written for AI
+> coding agents, but it reads fine for humans too.
 
 ## Creating new tournament notebook
 1. Add tournament scores in csv format into [tourney_data/raw_scores](https://github.com/akash-suresh/three-of-spades/tree/main/tourney_data/raw_scores). (follow same naming convention for the csv file as earlier tournaments)
-2. Add tournament entry in [TOURNAMENT_LIST_CHRONOLOGICAL](https://github.com/akash-suresh/three-of-spades/blob/main/utils/constants.py#L52) list.
+2. Add tournament entry in [TOURNAMENT_LIST_CHRONOLOGICAL](https://github.com/akash-suresh/three-of-spades/blob/main/utils/constants.py#L79) list — **in chronological order**, since Elo is computed by walking this list in sequence.
 3. Add a row to [`tourney_data/metadata.csv`](https://github.com/akash-suresh/three-of-spades/blob/main/tourney_data/metadata.csv) with the tournament's display name, location, flag emoji, dates, and year:
    ```
    id,name,location,flag,dates,year
    championship_9,My Tournament Name,London,🇬🇧,"March 1-3rd",2026
    ```
    The `id` must match the CSV filename (e.g. `championship_9.csv` → `championship_9`).
-4. Run the notebook — [notebook_gen.ipynb](https://github.com/akash-suresh/three-of-spades/blob/main/notebook_gen.ipynb) — to generate all tournament notebooks!
-5. Run the data pipeline to update the website:
+4. _(Optional)_ Run the notebook — [notebook_gen.ipynb](https://github.com/akash-suresh/three-of-spades/blob/main/notebook_gen.ipynb) — to generate all tournament notebooks. Note this re-executes **every** notebook, not just the new one, and rewrites ~40 large files. Notebooks haven't been generated since `tiny_championship_9`; the website is the live view now.
+5. Verify the data pipeline picks up the new tournament:
    ```bash
-   python process_data.py
+   pip install -r requirements.txt
+   python3 website/process_data.py
    ```
-   This regenerates `website/client/public/game_data.json` with updated Elo ratings, standings, pairwise stats, trio stats, bid & won, and career stats.
-6. Commit and raise a Pull request!
+   This recomputes Elo ratings, standings, pairwise stats, trio stats, bid & won, and career stats, and writes `website/client/public/game_data.json`. Check that your tournament appears in the output with the right player count, game count, and winner.
+
+   `game_data.json` is **generated and gitignored — don't commit it.** Netlify regenerates it on every deploy ([`netlify.toml`](./netlify.toml)).
+6. Commit the CSV, `metadata.csv`, and `constants.py` changes, then raise a Pull request!
 
 
 ## Adding additional analysis

--- a/website/WEBSITE_README.md
+++ b/website/WEBSITE_README.md
@@ -25,13 +25,16 @@ is automatically reflected the next time `process_data.py` is run.
 |---|---|---|
 | Dashboard | `/` | Hero, current rankings, rating history chart, all-time stats |
 | Rankings | `/rankings` | Full player cards, win-rate chart, radar profiles |
-| Tournaments | `/tournaments` | All 28 tournaments, filterable by type, most-recent-first |
+| Tournaments | `/tournaments` | All tournaments, filterable by type, most-recent-first |
 | Tournament Detail | `/tournaments/:id` | Standings, timeseries, win-ratio, pair/trio stats, bid & won, post-tournament leaderboard |
 | Head to Head | `/head-to-head` | Interactive pair selector, per-tournament breakdown, all-rivalry cards |
 
 ---
 
 ## How to Add a New Tournament
+
+See [`AGENTS.md`](../AGENTS.md) at the repo root for the full guide — CSV column
+contract, the files to touch, and the known traps. The short version:
 
 **Step 1 — Add the CSV**
 
@@ -45,7 +48,8 @@ international_friendly_5.csv
 
 **Step 2 — Register it in `utils/constants.py`**
 
-Append the new entry to `TOURNAMENT_LIST_CHRONOLOGICAL` (last item = most recent):
+Append the new entry to `TOURNAMENT_LIST_CHRONOLOGICAL` (last item = most recent).
+Order matters: Elo is computed by walking this list in sequence.
 ```python
 TOURNAMENT_LIST_CHRONOLOGICAL = [
     ...
@@ -53,17 +57,33 @@ TOURNAMENT_LIST_CHRONOLOGICAL = [
 ]
 ```
 
-**Step 3 — Regenerate the data**
+**Step 3 — Add a row to `tourney_data/metadata.csv`**
+
+This drives the display name, location, flag, and dates on the site. The `id` must
+match the CSV filename without `.csv`:
+```
+id,name,location,flag,dates,year
+championship_9,My Tournament Name,London,🇬🇧,"March 1-3rd",2026
+```
+
+**Step 4 — Regenerate the data**
 
 Run from the **repo root** (not from `website/`):
 ```bash
-python process_data.py
+pip install -r requirements.txt   # first time only
+python3 website/process_data.py
 ```
 
 This produces `website/client/public/game_data.json` with updated Elo ratings,
 standings, pairwise stats, trio stats, bid & won, and career stats for all players.
+Check the console output — your tournament should appear with the right player count,
+game count, and winner.
 
-**Step 4 — Preview locally**
+> Run `website/process_data.py`, **not** the `process_data.py` at the repo root. The
+> root copy is stale: it hardcodes `/home/ubuntu/...` paths and carries its own frozen
+> tournament list.
+
+**Step 5 — Preview locally**
 
 ```bash
 cd website
@@ -71,21 +91,21 @@ pnpm install   # first time only
 pnpm dev
 ```
 
-Open `http://localhost:5173` to verify the new tournament appears correctly.
+Open `http://localhost:3000` to verify the new tournament appears correctly.
 
-**Step 5 — Commit and push**
+**Step 6 — Commit and push**
 
 ```bash
 git add tourney_data/raw_scores/championship_9.csv
+git add tourney_data/metadata.csv
 git add utils/constants.py
-git add website/client/public/game_data.json
 git commit -m "Add Championship #9"
 git push
 ```
 
-> **Note:** `game_data.json` is gitignored by default to keep the repo lightweight.
-> If you want to commit it so the deployed site updates automatically on push,
-> remove `client/public/game_data.json` from `website/.gitignore`.
+> **Note:** `game_data.json` is gitignored and must **not** be committed. Netlify
+> regenerates it on every deploy by running `process_data.py` as part of the build,
+> so pushing the three source files above is enough to update the live site.
 
 ---
 
@@ -98,14 +118,18 @@ tournaments they participated in, but do not appear in the global rankings.
 
 Current core players (as of the last run): Akash, Nats, Prateek, Abhi, Ani, Naati, Skanda.
 
-To change the threshold, edit `CORE_PLAYER_GAME_THRESHOLD` in `process_data.py`.
+To change the threshold, edit `CORE_PLAYER_GAME_THRESHOLD` in `website/process_data.py`.
 
 ---
 
 ## Rating System
 
-The Elo-style rating system is identical to `utils/ranking_system.py` (`UniversalRatingSystem`).
-`process_data.py` calls `urs.addTournamentData(tournament)` directly — there is no manual port.
+The Elo-style rating system matches `utils/ranking_system.py` (`UniversalRatingSystem`).
+`website/process_data.py` imports `getAdjustmentMultiplier`, `BASE_RATING`, and
+`DENOMINATOR` from that module and replicates its per-game loop, rather than calling
+`UniversalRatingSystem` itself — it needs pre/post rating snapshots and milestone deltas
+for the website, which that class doesn't expose. The maths is the same; see the comment
+at `website/process_data.py:291`.
 
 Key parameters:
 - **Base rating:** 1000
@@ -120,18 +144,37 @@ Key parameters:
 ```bash
 cd website
 pnpm install
-pnpm dev        # starts Vite dev server on http://localhost:5173
-pnpm build      # production build → website/dist/
+pnpm dev        # starts Vite dev server on http://localhost:3000
+pnpm build      # production build → website/dist/public
 ```
+
+The dev server uses `strictPort: false`, so if 3000 is busy Vite will pick the next
+free port — check the console output for the actual URL.
+
+If you're only changing the frontend, you still need `game_data.json` to exist. Generate
+it once from the repo root with `python3 website/process_data.py`.
 
 ---
 
 ## Deploying
 
-The site is hosted on [Manus](https://manus.im). To deploy:
-1. Run `python process_data.py` from the repo root
-2. Open the Manus project and click **Publish** in the Management UI
+The site is hosted on **Netlify** and deploys automatically — pushing to `main` triggers
+a build. No manual publish step.
 
-Alternatively, the `website/` directory is a standard Vite project and can be deployed
-to any static hosting provider (Vercel, Netlify, Cloudflare Pages, etc.) by pointing
-the build command to `pnpm build` and the output directory to `dist/`.
+The build is defined in [`netlify.toml`](../netlify.toml) at the repo root:
+
+```toml
+[build]
+  base = "."
+  command = "pip install -r requirements.txt && python3 website/process_data.py && cd website && pnpm install && pnpm run build"
+  publish = "website/dist/public"
+```
+
+Netlify runs `process_data.py` as part of every build, which is why `game_data.json`
+is gitignored — the deployed site always regenerates it from the CSVs in
+`tourney_data/`. The build runs from the repo root so the script can reach both
+`tourney_data/` and `utils/`.
+
+The `website/` directory is otherwise a standard Vite project and can be deployed to any
+static host by pointing the build command at `pnpm build` and the publish directory at
+`dist/public`.


### PR DESCRIPTION
Adds a guide for adding/updating tournament scores, so a new contributor (human or AI agent) can do it without reverse-engineering the pipeline — and corrects the instructions in both READMEs that would have sent them down the wrong path.

Documentation only. No data, scores, or pipeline logic touched.

## What's here

**`AGENTS.md`** — the score-update guide. Covers the CSV column contract, the three files a new tournament touches, how to verify, and the traps. Named `AGENTS.md` for cross-agent portability.

**`CLAUDE.md`** — one line, `@AGENTS.md`. Claude Code reads `CLAUDE.md` natively and follows the import, so there's no duplicated content to drift.

**`README.md`** and **`website/WEBSITE_README.md`** — accuracy fixes, detailed below.

## Why the docs changed

Each of these was verified against the repo, not assumed.

### Both READMEs pointed at dead code

The root `process_data.py` hardcodes `DATA_DIR = "/home/ubuntu/tourney_data"` and carries its own frozen copy of the tournament list that stops at `international_friendly_4`. The live script is `website/process_data.py`, which imports from `utils/` and reads `metadata.csv` — that's what `netlify.toml` builds with. Following the old instruction would crash, or silently regenerate stale data.

### `game_data.json` was described as something to commit

It's gitignored (`website/.gitignore`) and rebuilt by Netlify on every deploy. `WEBSITE_README` step 5 said `git add website/client/public/game_data.json`, contradicting its own note eight lines further down. Both files now describe regeneration as a verification step.

### `WEBSITE_README` had wrong local-dev details

- Dev server is on **port 3000** (`vite.config.ts:171`), not 5173 — documented in two places.
- Build output is `dist/public` (`vite.config.ts:167`, matching `netlify.toml` publish), not `dist/`.
- The **`metadata.csv` step was missing entirely**, though the pipeline now requires it for display names and dates.
- Deploy section described Manus with a manual **Publish** click; the site is on Netlify and builds automatically.
- Rating-system section claimed `process_data.py` calls `urs.addTournamentData(tournament)`. It doesn't — `website/process_data.py:291` notes it uses `PlayerProfile` + `getAdjustmentMultiplier` directly because `UniversalRatingSystem` doesn't expose the pre/post snapshot hooks the site needs. Same maths, different call path.

### Smaller corrections

- Notebook generation marked optional: `notebook_gen.ipynb` re-executes *every* notebook from `template.ipynb`, rewriting ~40 files of ~250KB. None have been generated since `tiny_championship_9` — the last 10 tournaments have none.
- `TOURNAMENT_LIST_CHRONOLOGICAL` anchor was `#L52`; it's at line 79. Noted that ordering affects Elo.
- Dropped the hardcoded "28 tournaments" (it's 38) rather than replacing it with a number that will rot again.

## Verification

Pipeline runs clean on this branch:

```
Processed tiny_championship_17: 3 players, 69 games, winner: Akash
Total tournaments: 38
#1 Akash: 1196.4  #2 Prateek: 1114.5  #3 Nats: 1090.9
```

## Worth a follow-up

The dead root `process_data.py` is still present and is the main remaining trap. Deleting it felt out of scope here; happy to do it separately.

Also noting: the `Players` enum in `utils/constants.py` isn't referenced by any code path. Player identity comes entirely from CSV headers, so a misspelled header silently creates a new player rather than erroring. `AGENTS.md` documents this, but it may be worth a real validation check at some point.